### PR TITLE
DL-1847 Removed unnecessary polluting logging.

### DIFF
--- a/app/config/frontendGlobal.scala
+++ b/app/config/frontendGlobal.scala
@@ -61,7 +61,6 @@ class CgtErrorHandler @Inject()(val messagesApi: MessagesApi,
   override def onServerError(request: RequestHeader, exception: Throwable): Future[Result] = {
     exception match {
       case ApplicationException(result, _) =>
-        Logger.warn(s"Key-store None.get handled from: ${request.uri}")
         Future.successful(result.withHeaders(CACHE_CONTROL -> "no-cache,no-store,max-age=0"))
       case e => Future.successful(resolveError(request, e))
     }

--- a/app/controllers/utils/package.scala
+++ b/app/controllers/utils/package.scala
@@ -37,7 +37,6 @@ package object utils {
     def recoverToStart(homeLink:String, sessionTimeoutUrl: String)(implicit request: Request[_], ec: ExecutionContext): Future[Result] =
       future.recover {
         case e: NoSuchElementException =>
-          Logger.warn(s"TEST TEST ${request.uri} resulted in None.get, user redirected to start")
           throw ApplicationException(
             Redirect(controllers.routes.TimeoutController.timeout(homeLink, sessionTimeoutUrl)),
             "cgt-calculator-resident-properties-frontend" + e.getMessage


### PR DESCRIPTION
DL-1847 - NoneGetIssue 

Removed the noisy logging that can occur when a page is skipped. The **TEST TEST resulted in None.get, user redirected to start** message occurs when a page is navigated to and there is no data in the keystore cache.

## Checklist

 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date
