### PR TITLE
DL-2163 - updated dependencies to pull in updated version of simple r…

### DIFF
--- a/project/frontendBuild.scala
+++ b/project/frontendBuild.scala
@@ -35,13 +35,13 @@ private object AppDependencies {
   import play.core.PlayVersion
   import play.sbt.PlayImport._
 
-  val bootstrapVersion        = "0.39.0"
+  val bootstrapVersion        = "0.44.0"
   val jsonJodaVersion         = "2.6.10"
-  val govUKTemplateVersion    = "5.34.0-play-26"
-  val playUiVersion           = "7.39.0-play-26"
+  val govUKTemplateVersion    = "5.37.0-play-26"
+  val playUiVersion           = "7.40.0-play-26"
   val playPartialsVersion     = "6.9.0-play-26"
-  val httpCachingVersion      = "8.3.0"
-  val mongoCachingVersion     = "6.4.0-play-26"
+  val httpCachingVersion      = "8.4.0-play-26"
+  val mongoCachingVersion     = "6.6.0-play-26"
   val playLanguageVersion     = "3.4.0"
   val play2PdfVersion         = "1.5.1"
   val playJavaVersion         = "2.6.12"
@@ -68,7 +68,7 @@ private object AppDependencies {
   object Test {
     def apply(): Seq[ModuleID] = new TestDependencies {
       override lazy val test = Seq(
-        "uk.gov.hmrc" %% "hmrctest" % "3.8.0-play-26" % scope,
+        "uk.gov.hmrc" %% "hmrctest" % "3.9.0-play-26" % scope,
         "org.scalatestplus.play" %% "scalatestplus-play" % "2.0.0" % scope,
         "org.mockito" % "mockito-core" % "2.27.0" % scope,
         "org.pegdown" % "pegdown" % "1.6.0" % scope,


### PR DESCRIPTION
…eactive mongo

# DL-2163-  Update simple-reactive mongo dependencies

This service doesn't use Mongo or have a direct simple-reactive mongo reference defined.
A reference is pulled in via common dependencies though.
Updated the dependencies to bring in the later reactive-mongo sub dependency

## Checklist

 - [x ]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x ]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x ]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x ]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x ]  I've run a dependency check to ensure all dependencies are up to date