### PR TITLE
DL-2831 - Remove compilation unit test warnings on CGT-CALC-RES-PROP-FRONTEND

### DIFF
--- a/app/config/frontendGlobal.scala
+++ b/app/config/frontendGlobal.scala
@@ -67,7 +67,3 @@ class CgtErrorHandler @Inject()(val messagesApi: MessagesApi,
   }
 
 }
-
-object ControllerConfiguration extends ControllerConfig {
-  lazy val controllerConfigs: Config = Play.current.configuration.underlying.as[Config]("controllers")
-}

--- a/app/controllers/ReportController.scala
+++ b/app/controllers/ReportController.scala
@@ -27,7 +27,6 @@ import it.innove.play.pdf.PdfGenerator
 import javax.inject.{Singleton, Inject}
 import models.resident.TaxYearModel
 import models.resident.properties.YourAnswersSummaryModel
-import play.api.Play.current
 import play.api.i18n.{I18nSupport, Messages}
 import play.api.mvc.{MessagesControllerComponents, RequestHeader}
 import services.SessionCacheService

--- a/app/views/calculation/resident/properties/report/deductionsSummaryReport.scala.html
+++ b/app/views/calculation/resident/properties/report/deductionsSummaryReport.scala.html
@@ -24,7 +24,7 @@
 @import views.html.helpers.deductionsSummaryPartial
 @import play.api.Application
 
-@(gainAnswers: YourAnswersSummaryModel, deductionAnswers: ChargeableGainAnswers, result: ChargeableGainResultModel, taxYear: TaxYearModel, totalCosts: BigDecimal)(implicit request: Request[_], messages: Messages, applgication: Application, lang: Lang)
+@(gainAnswers: YourAnswersSummaryModel, deductionAnswers: ChargeableGainAnswers, result: ChargeableGainResultModel, taxYear: TaxYearModel, totalCosts: BigDecimal)(implicit request: Request[_], messages: Messages, lang: Lang)
 
 <!DOCTYPE html>
 <html>

--- a/app/views/calculation/resident/properties/report/finalSummaryReport.scala.html
+++ b/app/views/calculation/resident/properties/report/finalSummaryReport.scala.html
@@ -32,7 +32,7 @@
     lettingsReliefUsed: Option[Boolean] = None,
     totalCosts: BigDecimal,
     totalDeductions: BigDecimal,
-    aeaRemaining: BigDecimal)(implicit request: Request[_], messages: Messages, application: Application, lang: Lang)
+    aeaRemaining: BigDecimal)(implicit request: Request[_], messages: Messages, lang: Lang)
 
 <!DOCTYPE html>
 <html>

--- a/app/views/calculation/resident/properties/report/gainSummaryReport.scala.html
+++ b/app/views/calculation/resident/properties/report/gainSummaryReport.scala.html
@@ -22,7 +22,7 @@
 @import views.html.helpers.checkYourAnswersPartial
 @import play.api.Application
 
-@(answers: YourAnswersSummaryModel, gain: BigDecimal, taxYear: TaxYearModel, totalCosts: BigDecimal, maxAea: BigDecimal)(implicit request: Request[_], messages: Messages, application: Application, lang: Lang)
+@(answers: YourAnswersSummaryModel, gain: BigDecimal, taxYear: TaxYearModel, totalCosts: BigDecimal, maxAea: BigDecimal)(implicit request: Request[_], messages: Messages, lang: Lang)
 
 <!DOCTYPE html>
 <html>

--- a/build.sbt
+++ b/build.sbt
@@ -37,7 +37,12 @@ lazy val microservice = Project(appName, file("."))
     libraryDependencies ++= AppDependencies(),
     retrieveManaged := true,
     evictionWarningOptions in update := EvictionWarningOptions.default.withWarnScalaVersionEviction(false),
-    pipelineStages in Assets := Seq(digest)
+    pipelineStages in Assets := Seq(digest),
+    scalacOptions += "-P:silencer:pathFilters=views;routes",
+    libraryDependencies ++= Seq(
+      compilerPlugin("com.github.ghik" % "silencer-plugin" % "1.6.0" cross CrossVersion.full),
+      "com.github.ghik" % "silencer-lib" % "1.6.0" % Provided cross CrossVersion.full
+    ),
   )
   .configs(IntegrationTest)
   .settings(inConfig(IntegrationTest)(Defaults.itSettings): _*)

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -20,10 +20,10 @@ import play.sbt.PlayImport._
 
 object AppDependencies {
 
-  val bootstrapVersion        = "1.3.0"
+  val bootstrapVersion        = "1.5.0"
   val jsonJodaVersion         = "2.7.4"
-  val govUKTemplateVersion    = "5.48.0-play-26"
-  val playUiVersion           = "8.7.0-play-26"
+  val govUKTemplateVersion    = "5.52.0-play-26"
+  val playUiVersion           = "8.8.0-play-26"
   val playPartialsVersion     = "6.9.0-play-26"
   val httpCachingVersion      = "9.0.0-play-26"
   val mongoCachingVersion     = "6.8.0-play-26"
@@ -53,9 +53,9 @@ object AppDependencies {
       override lazy val test = Seq(
         "uk.gov.hmrc" %% "hmrctest" % "3.9.0-play-26" % scope,
         "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.3" % scope,
-        "org.mockito" % "mockito-core" % "3.2.4" % scope,
+        "org.mockito" % "mockito-core" % "3.3.1" % scope,
         "org.pegdown" % "pegdown" % "1.6.0" % scope,
-        "org.jsoup" % "jsoup" % "1.12.1" % scope,
+        "org.jsoup" % "jsoup" % "1.13.1" % scope,
         "com.typesafe.play" %% "play-test" % PlayVersion.current % scope,
         "uk.gov.hmrc" %% "bootstrap-play-26" % bootstrapVersion % scope
       )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,16 +1,16 @@
 resolvers += Resolver.url("HMRC Sbt Plugin Releases", url("https://dl.bintray.com/hmrc/sbt-plugin-releases"))(Resolver.ivyStylePatterns)
-resolvers += "Typesafe Releases" at "http://repo.typesafe.com/typesafe/releases/"
+resolvers += "Typesafe Releases" at "https://repo.typesafe.com/typesafe/releases/"
 resolvers += Resolver.url("scoverage-bintray", url("https://dl.bintray.com/sksamuel/sbt-plugins/"))(Resolver.ivyStylePatterns)
 
 resolvers += "HMRC Releases" at "https://dl.bintray.com/hmrc/releases"
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.5.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.6.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "2.1.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.0.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "1.0.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "1.2.0")
 
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.25")
 

--- a/test/common/DatesSpec.scala
+++ b/test/common/DatesSpec.scala
@@ -19,12 +19,13 @@ package common
 import java.time.LocalDate
 
 import common.Dates.formatter
-import org.scalatestplus.play.OneAppPerSuite
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.i18n.{Lang, Messages, MessagesApi}
-import play.api.libs.concurrent.Execution.Implicits._
 import uk.gov.hmrc.play.test.UnitSpec
 
-class DatesSpec extends UnitSpec with OneAppPerSuite {
+import scala.concurrent.ExecutionContext
+
+class DatesSpec extends UnitSpec with GuiceOneAppPerSuite {
 
   "Calling constructDate method" should {
 
@@ -56,6 +57,7 @@ class DatesSpec extends UnitSpec with OneAppPerSuite {
 
   "Calling getCurrent Tax Year" should {
     "return the current tax year in the form YYYY/YY" in {
+      implicit val ec: ExecutionContext = app.injector.instanceOf[ExecutionContext]
       for {
         date <- Dates.getCurrentTaxYear
       } yield date.length shouldEqual 7

--- a/test/config/FrontendGlobalSpec.scala
+++ b/test/config/FrontendGlobalSpec.scala
@@ -17,7 +17,7 @@
 package config
 
 import org.jsoup.Jsoup
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.i18n.MessagesApi
 import play.api.test.FakeRequest
 import uk.gov.hmrc.http.SessionKeys

--- a/test/connectors/CalculatorConnectorSpec.scala
+++ b/test/connectors/CalculatorConnectorSpec.scala
@@ -29,7 +29,7 @@ import org.joda.time.DateTime
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
 import org.mockito.stubbing.OngoingStubbing
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.http.logging.SessionId
 import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}

--- a/test/connectors/SessionCacheConnectorSpec.scala
+++ b/test/connectors/SessionCacheConnectorSpec.scala
@@ -18,7 +18,7 @@ package connectors
 
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito.when
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.libs.json.Json
 import play.shaded.ahc.org.asynchttpclient.exception.RemotelyClosedException
 import uk.gov.hmrc.http.cache.client.{CacheMap, SessionCache}

--- a/test/controllers/TimeoutControllerSpec.scala
+++ b/test/controllers/TimeoutControllerSpec.scala
@@ -21,7 +21,7 @@ import akka.stream.{ActorMaterializer, Materializer}
 import controllers.helpers.{CommonMocks, FakeRequestHelper}
 import org.jsoup.Jsoup
 import org.mockito.Mockito.when
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.i18n.Messages
 import play.api.mvc.{Action, AnyContent}
 import play.api.test.FakeRequest

--- a/test/controllers/WhatNextNonSaControllerSpec.scala
+++ b/test/controllers/WhatNextNonSaControllerSpec.scala
@@ -23,7 +23,7 @@ import assets.MessageLookup
 import controllers.helpers.{CommonMocks, FakeRequestHelper}
 import org.jsoup.Jsoup
 import org.mockito.Mockito.when
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers.redirectLocation
 import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
 

--- a/test/controllers/helpers/CommonMocks.scala
+++ b/test/controllers/helpers/CommonMocks.scala
@@ -18,7 +18,7 @@ package controllers.helpers
 
 import config.AppConfig
 import connectors.{CalculatorConnector, SessionCacheConnector}
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.i18n.MessagesApi
 import play.api.mvc._
 import play.api.test.Helpers._

--- a/test/controllers/resident/properties/DeductionsControllerSpec/LettingsReliefActionSpec.scala
+++ b/test/controllers/resident/properties/DeductionsControllerSpec/LettingsReliefActionSpec.scala
@@ -26,7 +26,7 @@ import models.resident.properties.LettingsReliefModel
 import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers._
 import uk.gov.hmrc.http.cache.client.CacheMap
 import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}

--- a/test/controllers/resident/properties/DeductionsControllerSpec/LettingsReliefValueActionSpec.scala
+++ b/test/controllers/resident/properties/DeductionsControllerSpec/LettingsReliefValueActionSpec.scala
@@ -27,7 +27,7 @@ import models.resident.properties.{LettingsReliefValueModel, PrivateResidenceRel
 import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers._
 import uk.gov.hmrc.http.cache.client.CacheMap
 import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}

--- a/test/controllers/resident/properties/DeductionsControllerSpec/LossesBroughtForwardActionSpec.scala
+++ b/test/controllers/resident/properties/DeductionsControllerSpec/LossesBroughtForwardActionSpec.scala
@@ -29,7 +29,7 @@ import models.resident.properties.{ChargeableGainAnswers, LettingsReliefModel, P
 import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers._
 import uk.gov.hmrc.http.cache.client.CacheMap
 import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}

--- a/test/controllers/resident/properties/DeductionsControllerSpec/LossesBroughtForwardValueActionSpec.scala
+++ b/test/controllers/resident/properties/DeductionsControllerSpec/LossesBroughtForwardValueActionSpec.scala
@@ -27,7 +27,7 @@ import models.resident.properties.{ChargeableGainAnswers, YourAnswersSummaryMode
 import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers._
 import uk.gov.hmrc.http.cache.client.CacheMap
 import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}

--- a/test/controllers/resident/properties/DeductionsControllerSpec/PrivateResidenceReliefActionSpec.scala
+++ b/test/controllers/resident/properties/DeductionsControllerSpec/PrivateResidenceReliefActionSpec.scala
@@ -26,7 +26,7 @@ import models.resident.PrivateResidenceReliefModel
 import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers._
 import uk.gov.hmrc.http.cache.client.CacheMap
 import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}

--- a/test/controllers/resident/properties/DeductionsControllerSpec/PrivateResidenceReliefValueActionSpec.scala
+++ b/test/controllers/resident/properties/DeductionsControllerSpec/PrivateResidenceReliefValueActionSpec.scala
@@ -26,7 +26,7 @@ import models.resident.properties.{PrivateResidenceReliefValueModel, YourAnswers
 import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers._
 import uk.gov.hmrc.http.cache.client.CacheMap
 import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}

--- a/test/controllers/resident/properties/DeductionsControllerSpec/PropertyLivedInActionSpec.scala
+++ b/test/controllers/resident/properties/DeductionsControllerSpec/PropertyLivedInActionSpec.scala
@@ -26,7 +26,7 @@ import models.resident.properties.PropertyLivedInModel
 import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers._
 import uk.gov.hmrc.http.cache.client.CacheMap
 import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}

--- a/test/controllers/resident/properties/GainControllerSpec/AcquisitionCostsActionSpec.scala
+++ b/test/controllers/resident/properties/GainControllerSpec/AcquisitionCostsActionSpec.scala
@@ -29,7 +29,7 @@ import models.resident.properties.{BoughtForLessThanWorthModel, HowBecameOwnerMo
 import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers._
 import uk.gov.hmrc.http.cache.client.CacheMap
 import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}

--- a/test/controllers/resident/properties/GainControllerSpec/AcquisitionValueActionSpec.scala
+++ b/test/controllers/resident/properties/GainControllerSpec/AcquisitionValueActionSpec.scala
@@ -27,7 +27,7 @@ import models.resident.AcquisitionValueModel
 import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers._
 import uk.gov.hmrc.http.cache.client.CacheMap
 import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}

--- a/test/controllers/resident/properties/GainControllerSpec/BoughtForLessThanWorthActionSpec.scala
+++ b/test/controllers/resident/properties/GainControllerSpec/BoughtForLessThanWorthActionSpec.scala
@@ -27,7 +27,7 @@ import models.resident.properties.BoughtForLessThanWorthModel
 import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers._
 import uk.gov.hmrc.http.cache.client.CacheMap
 import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}

--- a/test/controllers/resident/properties/GainControllerSpec/DisposalCostsActionSpec.scala
+++ b/test/controllers/resident/properties/GainControllerSpec/DisposalCostsActionSpec.scala
@@ -28,7 +28,7 @@ import models.resident.{DisposalCostsModel, SellForLessModel}
 import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers._
 import uk.gov.hmrc.http.cache.client.CacheMap
 import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}

--- a/test/controllers/resident/properties/GainControllerSpec/DisposalDateActionSpec.scala
+++ b/test/controllers/resident/properties/GainControllerSpec/DisposalDateActionSpec.scala
@@ -29,7 +29,7 @@ import models.resident.{DisposalDateModel, TaxYearModel}
 import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers._
 import uk.gov.hmrc.http.cache.client.CacheMap
 import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}

--- a/test/controllers/resident/properties/GainControllerSpec/DisposalValueActionSpec.scala
+++ b/test/controllers/resident/properties/GainControllerSpec/DisposalValueActionSpec.scala
@@ -27,7 +27,7 @@ import models.resident.DisposalValueModel
 import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers._
 import uk.gov.hmrc.http.cache.client.CacheMap
 import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}

--- a/test/controllers/resident/properties/GainControllerSpec/HowBecameOwnerActionSpec.scala
+++ b/test/controllers/resident/properties/GainControllerSpec/HowBecameOwnerActionSpec.scala
@@ -26,7 +26,7 @@ import models.resident.properties.HowBecameOwnerModel
 import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers._
 import uk.gov.hmrc.http.cache.client.CacheMap
 import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}

--- a/test/controllers/resident/properties/GainControllerSpec/ImprovementsActionSpec.scala
+++ b/test/controllers/resident/properties/GainControllerSpec/ImprovementsActionSpec.scala
@@ -28,7 +28,7 @@ import models.resident.properties.{ImprovementsModel, YourAnswersSummaryModel}
 import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers._
 import uk.gov.hmrc.http.cache.client.CacheMap
 import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}

--- a/test/controllers/resident/properties/GainControllerSpec/NoTaxToPayActionSpec.scala
+++ b/test/controllers/resident/properties/GainControllerSpec/NoTaxToPayActionSpec.scala
@@ -27,7 +27,7 @@ import models.resident.properties.gain.WhoDidYouGiveItToModel
 import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers._
 import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
 

--- a/test/controllers/resident/properties/GainControllerSpec/OutsideTaxYearsActionSpec.scala
+++ b/test/controllers/resident/properties/GainControllerSpec/OutsideTaxYearsActionSpec.scala
@@ -26,7 +26,7 @@ import models.resident.{DisposalDateModel, TaxYearModel}
 import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers._
 import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
 

--- a/test/controllers/resident/properties/GainControllerSpec/OwnerBeforeLegislationStartActionSpec.scala
+++ b/test/controllers/resident/properties/GainControllerSpec/OwnerBeforeLegislationStartActionSpec.scala
@@ -27,7 +27,7 @@ import models.resident.properties.gain.OwnerBeforeLegislationStartModel
 import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers._
 import uk.gov.hmrc.http.cache.client.CacheMap
 import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}

--- a/test/controllers/resident/properties/GainControllerSpec/SellForLessActionSpec.scala
+++ b/test/controllers/resident/properties/GainControllerSpec/SellForLessActionSpec.scala
@@ -27,7 +27,7 @@ import models.resident.SellForLessModel
 import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers._
 import uk.gov.hmrc.http.cache.client.CacheMap
 import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}

--- a/test/controllers/resident/properties/GainControllerSpec/SellOrGiveAwayActionSpec.scala
+++ b/test/controllers/resident/properties/GainControllerSpec/SellOrGiveAwayActionSpec.scala
@@ -26,7 +26,7 @@ import models.resident.properties.SellOrGiveAwayModel
 import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers._
 import uk.gov.hmrc.http.cache.client.CacheMap
 import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}

--- a/test/controllers/resident/properties/GainControllerSpec/ValueBeforeLegislationStartActionSpec.scala
+++ b/test/controllers/resident/properties/GainControllerSpec/ValueBeforeLegislationStartActionSpec.scala
@@ -27,7 +27,7 @@ import models.resident.properties.ValueBeforeLegislationStartModel
 import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers._
 import uk.gov.hmrc.http.cache.client.CacheMap
 import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}

--- a/test/controllers/resident/properties/GainControllerSpec/WhoDidYouGiveItToActionSpec.scala
+++ b/test/controllers/resident/properties/GainControllerSpec/WhoDidYouGiveItToActionSpec.scala
@@ -27,7 +27,7 @@ import models.resident.properties.gain.WhoDidYouGiveItToModel
 import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers._
 import uk.gov.hmrc.http.cache.client.CacheMap
 import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}

--- a/test/controllers/resident/properties/GainControllerSpec/WorthWhenBoughtForLessActionSpec.scala
+++ b/test/controllers/resident/properties/GainControllerSpec/WorthWhenBoughtForLessActionSpec.scala
@@ -27,7 +27,7 @@ import models.resident.properties.WorthWhenBoughtForLessModel
 import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers._
 import uk.gov.hmrc.http.cache.client.CacheMap
 import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}

--- a/test/controllers/resident/properties/GainControllerSpec/WorthWhenGaveAwayActionSpec.scala
+++ b/test/controllers/resident/properties/GainControllerSpec/WorthWhenGaveAwayActionSpec.scala
@@ -27,7 +27,7 @@ import models.resident.properties.WorthWhenGaveAwayModel
 import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers._
 import uk.gov.hmrc.http.cache.client.CacheMap
 import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}

--- a/test/controllers/resident/properties/GainControllerSpec/WorthWhenGiftedActionSpec.scala
+++ b/test/controllers/resident/properties/GainControllerSpec/WorthWhenGiftedActionSpec.scala
@@ -27,7 +27,7 @@ import models.resident.properties.gain.WorthWhenGiftedModel
 import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers._
 import uk.gov.hmrc.http.cache.client.CacheMap
 import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}

--- a/test/controllers/resident/properties/GainControllerSpec/WorthWhenInheritedActionSpec.scala
+++ b/test/controllers/resident/properties/GainControllerSpec/WorthWhenInheritedActionSpec.scala
@@ -27,7 +27,7 @@ import models.resident.WorthWhenInheritedModel
 import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers._
 import uk.gov.hmrc.http.cache.client.CacheMap
 import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}

--- a/test/controllers/resident/properties/GainControllerSpec/WorthWhenSoldForLessActionSpec.scala
+++ b/test/controllers/resident/properties/GainControllerSpec/WorthWhenSoldForLessActionSpec.scala
@@ -27,7 +27,7 @@ import models.resident.WorthWhenSoldForLessModel
 import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers._
 import uk.gov.hmrc.http.cache.client.CacheMap
 import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}

--- a/test/controllers/resident/properties/IncomeControllerSpec/CurrentIncomeActionSpec.scala
+++ b/test/controllers/resident/properties/IncomeControllerSpec/CurrentIncomeActionSpec.scala
@@ -29,7 +29,7 @@ import models.resident.income._
 import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers._
 import uk.gov.hmrc.http.cache.client.CacheMap
 import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}

--- a/test/controllers/resident/properties/IncomeControllerSpec/PersonalAllowanceActionSpec.scala
+++ b/test/controllers/resident/properties/IncomeControllerSpec/PersonalAllowanceActionSpec.scala
@@ -28,7 +28,7 @@ import models.resident.{DisposalDateModel, TaxYearModel}
 import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers._
 import uk.gov.hmrc.http.cache.client.CacheMap
 import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}

--- a/test/controllers/resident/properties/PropertiesControllerSpec/IntroductionActionSpec.scala
+++ b/test/controllers/resident/properties/PropertiesControllerSpec/IntroductionActionSpec.scala
@@ -23,7 +23,7 @@ import controllers.PropertiesController
 import controllers.helpers.{CommonMocks, FakeRequestHelper}
 import org.jsoup.Jsoup
 import org.mockito.Mockito.when
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.mvc.Result
 import play.api.test.Helpers._
 import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}

--- a/test/controllers/resident/properties/ReportControllerSpec/DeductionsSummaryActionSpec.scala
+++ b/test/controllers/resident/properties/ReportControllerSpec/DeductionsSummaryActionSpec.scala
@@ -26,7 +26,7 @@ import models.resident._
 import models.resident.properties._
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.mvc.RequestHeader
 import play.api.test.Helpers._
 import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}

--- a/test/controllers/resident/properties/ReportControllerSpec/FinalSummaryActionSpec.scala
+++ b/test/controllers/resident/properties/ReportControllerSpec/FinalSummaryActionSpec.scala
@@ -28,7 +28,7 @@ import models.resident.income.{CurrentIncomeModel, PersonalAllowanceModel}
 import models.resident.properties.{ChargeableGainAnswers, PropertyLivedInModel, YourAnswersSummaryModel}
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.mvc.RequestHeader
 import play.api.test.Helpers._
 import services.SessionCacheService

--- a/test/controllers/resident/properties/ReportControllerSpec/GainSummaryActionSpec.scala
+++ b/test/controllers/resident/properties/ReportControllerSpec/GainSummaryActionSpec.scala
@@ -26,7 +26,7 @@ import models.resident.TaxYearModel
 import models.resident.properties.YourAnswersSummaryModel
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.mvc.RequestHeader
 import play.api.test.Helpers._
 import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}

--- a/test/controllers/resident/properties/ReviewAnswersControllerSpec.scala
+++ b/test/controllers/resident/properties/ReviewAnswersControllerSpec.scala
@@ -32,7 +32,7 @@ import models.resident.properties._
 import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers.redirectLocation
 import services.SessionCacheService
 import uk.gov.hmrc.http.HeaderCarrier

--- a/test/controllers/resident/properties/SaUserControllerSpec.scala
+++ b/test/controllers/resident/properties/SaUserControllerSpec.scala
@@ -26,7 +26,7 @@ import models.resident.{ChargeableGainResultModel, TotalGainAndTaxOwedModel}
 import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers._
 import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
 

--- a/test/controllers/resident/properties/SummaryActionSpec.scala
+++ b/test/controllers/resident/properties/SummaryActionSpec.scala
@@ -29,7 +29,7 @@ import models.resident.properties._
 import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers._
 import services.SessionCacheService
 import uk.gov.hmrc.http.HeaderCarrier

--- a/test/controllers/resident/properties/WhatNextSaControllerSpec.scala
+++ b/test/controllers/resident/properties/WhatNextSaControllerSpec.scala
@@ -27,7 +27,7 @@ import models.resident.DisposalDateModel
 import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers._
 import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
 

--- a/test/forms/resident/SaUserFormSpec.scala
+++ b/test/forms/resident/SaUserFormSpec.scala
@@ -19,10 +19,10 @@ package forms.resident
 import assets.MessageLookup.{SaUser => messages}
 import forms.resident.SaUserForm._
 import models.resident.SaUserModel
-import org.scalatestplus.play.OneAppPerSuite
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import uk.gov.hmrc.play.test.UnitSpec
 
-class SaUserFormSpec extends UnitSpec with OneAppPerSuite {
+class SaUserFormSpec extends UnitSpec with GuiceOneAppPerSuite {
 
   "Creating a form using a valid model" should {
 

--- a/test/services/SessionCacheServiceSpec.scala
+++ b/test/services/SessionCacheServiceSpec.scala
@@ -26,7 +26,7 @@ import models.resident.properties.gain.OwnerBeforeLegislationStartModel
 import models.resident.{DisposalDateModel, IncomeAnswersModel, SellForLessModel}
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito.when
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.mvc.Results.Redirect
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.bootstrap.http.ApplicationException

--- a/test/views/BaseViewSpec.scala
+++ b/test/views/BaseViewSpec.scala
@@ -19,7 +19,7 @@ package views
 import controllers.helpers.{CommonMocks, FakeRequestHelper}
 import org.mockito.Mockito.when
 import org.scalatest.Suite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.i18n.Messages
 import uk.gov.hmrc.play.test.WithFakeApplication
 

--- a/test/views/resident/properties/report/PropertiesDeductionsReportViewSpec.scala
+++ b/test/views/resident/properties/report/PropertiesDeductionsReportViewSpec.scala
@@ -73,7 +73,7 @@ class PropertiesDeductionsReportViewSpec extends UnitSpec with WithFakeApplicati
 
     lazy val taxYearModel = TaxYearModel("2015/16", true, "2015/16")
 
-    lazy val view = views.deductionsSummaryReport(gainAnswers, deductionAnswers, results, taxYearModel, 1000)(fakeRequestWithSession, testingMessages, fakeApplication, fakeLang)
+    lazy val view = views.deductionsSummaryReport(gainAnswers, deductionAnswers, results, taxYearModel, 1000)(fakeRequestWithSession, testingMessages, fakeLang)
     lazy val doc = Jsoup.parse(view.body)
 
     "have a charset of UTF-8" in {
@@ -157,7 +157,7 @@ class PropertiesDeductionsReportViewSpec extends UnitSpec with WithFakeApplicati
 
     lazy val taxYearModel = TaxYearModel("2013/14", false, "2015/16")
 
-    lazy val view = views.deductionsSummaryReport(gainAnswers, deductionAnswers, results, taxYearModel, 5000)(fakeRequestWithSession, testingMessages, fakeApplication, fakeLang)
+    lazy val view = views.deductionsSummaryReport(gainAnswers, deductionAnswers, results, taxYearModel, 5000)(fakeRequestWithSession, testingMessages, fakeLang)
     lazy val doc = Jsoup.parse(view.body)
 
 

--- a/test/views/resident/properties/report/PropertiesFinalReportViewSpec.scala
+++ b/test/views/resident/properties/report/PropertiesFinalReportViewSpec.scala
@@ -84,7 +84,7 @@ class PropertiesFinalReportViewSpec extends UnitSpec with WithFakeApplication wi
     lazy val taxYearModel = TaxYearModel("2015/16", isValidYear = true, "2015/16")
 
     lazy val view = views.finalSummaryReport(gainAnswers, deductionAnswers, incomeAnswers, results,
-      taxYearModel, isCurrentTaxYear = false, Some(true), Some(true), 100, 100, 0)(fakeRequestWithSession, testingMessages, fakeApplication, fakeLang)
+      taxYearModel, isCurrentTaxYear = false, Some(true), Some(true), 100, 100, 0)(fakeRequestWithSession, testingMessages, fakeLang)
     lazy val doc = Jsoup.parse(view.body)
 
     s"have a title ${messages.title}" in {

--- a/test/views/resident/properties/report/PropertiesGainReportViewSpec.scala
+++ b/test/views/resident/properties/report/PropertiesGainReportViewSpec.scala
@@ -55,7 +55,7 @@ class PropertiesGainReportViewSpec extends UnitSpec with WithFakeApplication wit
 
     lazy val taxYearModel = TaxYearModel("2015/16", true, "2015/16")
 
-    lazy val view = views.gainSummaryReport(testModel, -2000, taxYearModel, 1000, 2000)(fakeRequest, testingMessages, fakeApplication, fakeLang)
+    lazy val view = views.gainSummaryReport(testModel, -2000, taxYearModel, 1000, 2000)(fakeRequest, testingMessages, fakeLang)
     lazy val doc = Jsoup.parse(view.body)
 
     s"have a title ${messages.title}" in {
@@ -119,7 +119,7 @@ class PropertiesGainReportViewSpec extends UnitSpec with WithFakeApplication wit
       Some(false)
     )
 
-    lazy val view = views.gainSummaryReport(testModel, 0, taxYearModel, 1000, 4000)(fakeRequest, testingMessages, fakeApplication, fakeLang)
+    lazy val view = views.gainSummaryReport(testModel, 0, taxYearModel, 1000, 4000)(fakeRequest, testingMessages, fakeLang)
     lazy val doc = Jsoup.parse(view.body)
 
     "have a banner for tax owed" in {


### PR DESCRIPTION
# DL-2831 - Remove compilation unit test warnings on CGT-CALC-RES-PROP-FRONTEND

Removed all warnings from `cgt-calculator-resident-properties-frontend`

## Checklist

 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [ ]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date
