### PR TITLE
DL-4355 Define the correct `host` for pdf generation

### DIFF
--- a/app/controllers/ReportController.scala
+++ b/app/controllers/ReportController.scala
@@ -27,6 +27,7 @@ import it.innove.play.pdf.PdfGenerator
 import javax.inject.{Singleton, Inject}
 import models.resident.TaxYearModel
 import models.resident.properties.YourAnswersSummaryModel
+import play.api.Configuration
 import play.api.i18n.{I18nSupport, Messages}
 import play.api.mvc.{MessagesControllerComponents, RequestHeader}
 import services.SessionCacheService
@@ -38,6 +39,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class ReportController @Inject()(
+                                  val config: Configuration,
                                   val calcConnector: CalculatorConnector,
                                   val sessionCacheService : SessionCacheService,
                                   val messagesControllerComponents: MessagesControllerComponents,
@@ -47,11 +49,11 @@ class ReportController @Inject()(
   override lazy val homeLink: String = controllers.routes.PropertiesController.introduction().url
   override lazy val sessionTimeoutUrl: String = homeLink
 
+  lazy val platformHost: Option[String] = config.getOptional[String]("platform.frontend.host")
+
   implicit val ec: ExecutionContext = messagesControllerComponents.executionContext
 
-  def host(implicit request: RequestHeader): String = {
-    s"http://${request.host}/"
-  }
+  def host(implicit request: RequestHeader): String = platformHost.getOrElse(s"http://${request.host}")
 
   def getTaxYear(disposalDate: LocalDate)(implicit hc: HeaderCarrier): Future[Option[TaxYearModel]] =
     calcConnector.getTaxYear(disposalDate.format(requestFormatter))

--- a/test/controllers/ReportControllerTestSpec.scala
+++ b/test/controllers/ReportControllerTestSpec.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import controllers.helpers.FakeRequestHelper
+import org.scalatestplus.mockito.MockitoSugar
+import play.api.Application
+import play.api.inject.guice.GuiceApplicationBuilder
+import uk.gov.hmrc.play.test.UnitSpec
+
+class ReportControllerTestSpec extends UnitSpec with FakeRequestHelper with MockitoSugar {
+
+  def buildApp(properties: Map[String, String]): Application = {
+    new GuiceApplicationBuilder().configure(properties + ("metrics.enabled" -> "false")).build()
+  }
+
+  "host" should {
+    "return the `platform frontend host` when it has been set in configuration" in {
+      implicit val application: Application = buildApp(Map("platform.frontend.host" -> "https://www.qa.tax.service.gov.uk/"))
+      val controller = application.injector.instanceOf[ReportController]
+      controller.host(fakeRequest) shouldBe "https://www.qa.tax.service.gov.uk/"
+    }
+    "return the request host when the `platform frontend host` isn't present in configuration" in {
+      implicit val application: Application = buildApp(Map.empty)
+      val controller = application.injector.instanceOf[ReportController]
+      controller.host(fakeRequest) shouldBe "http://localhost"
+    }
+  }
+
+}

--- a/test/controllers/resident/properties/ReportControllerSpec/DeductionsSummaryActionSpec.scala
+++ b/test/controllers/resident/properties/ReportControllerSpec/DeductionsSummaryActionSpec.scala
@@ -66,7 +66,7 @@ class DeductionsSummaryActionSpec @Inject()(val pdfGenerator: PdfGenerator) exte
     when(mockCalcConnector.getPropertyTotalCosts(ArgumentMatchers.any())(ArgumentMatchers.any()))
     .thenReturn(Future.successful(BigDecimal(10000)))
 
-    new ReportController(mockCalcConnector, mockSessionCacheService, mockMessagesControllerComponents, pdfGenerator) {
+    new ReportController(fakeApplication.configuration, mockCalcConnector, mockSessionCacheService, mockMessagesControllerComponents, pdfGenerator) {
       override def host(implicit request: RequestHeader): String = "http://localhost:9977/"
     }
   }

--- a/test/controllers/resident/properties/ReportControllerSpec/FinalSummaryActionSpec.scala
+++ b/test/controllers/resident/properties/ReportControllerSpec/FinalSummaryActionSpec.scala
@@ -81,7 +81,7 @@ class FinalSummaryActionSpec @Inject()(val pdfGenerator: PdfGenerator) extends U
     when(mockCalculatorConnector.getPropertyTotalCosts(ArgumentMatchers.any())(ArgumentMatchers.any()))
       .thenReturn(Future.successful(BigDecimal(1000)))
 
-    new ReportController(mockCalculatorConnector, mockSessionCacheService, mockMessagesControllerComponents, pdfGenerator) {
+    new ReportController(fakeApplication.configuration, mockCalculatorConnector, mockSessionCacheService, mockMessagesControllerComponents, pdfGenerator) {
       override def host(implicit request: RequestHeader): String = "http://localhost:9977/"
     }
   }

--- a/test/controllers/resident/properties/ReportControllerSpec/GainSummaryActionSpec.scala
+++ b/test/controllers/resident/properties/ReportControllerSpec/GainSummaryActionSpec.scala
@@ -56,7 +56,7 @@ class GainSummaryActionSpec @Inject()(val pdfGenerator: PdfGenerator) extends Un
     when(mockCalcConnector.getFullAEA(ArgumentMatchers.any())(ArgumentMatchers.any()))
       .thenReturn(Future.successful(Some(BigDecimal(10000))))
 
-    new ReportController(mockCalcConnector, mockSessionCacheService, mockMessagesControllerComponents, pdfGenerator) {
+    new ReportController(fakeApplication.configuration, mockCalcConnector, mockSessionCacheService, mockMessagesControllerComponents, pdfGenerator) {
       override def host(implicit request: RequestHeader): String = "http://localhost:9977/"
     }
   }


### PR DESCRIPTION
# DL-4355 Define the correct `host` for pdf generation

**Bug fix**

The pdf generation requires the domain to be specified so that the pdf generation can fetch the CSS. As the platform are/have enforced HTTPS the existing code was causing the request to hang and does not produce a PDF for the user.

Uses the `platform.frontend-host` configuration if present, for the domain name else it will default to http://localhost:port (which would only trigger locally)


## Checklist

 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
