### PR TITLE
DL-9854 - Added continue button IDs

### DIFF
--- a/app/views/calculation/resident/properties/summary/deductionsSummary.scala.html
+++ b/app/views/calculation/resident/properties/summary/deductionsSummary.scala.html
@@ -97,7 +97,7 @@
     </br>
 
     @if(taxYear.isValidYear) {
-        <a class="govuk-button" href="@controllers.routes.SaUserController.saUser.url">@Messages("calc.base.button.continue")</a>
+        <a id="continue-button" class="govuk-button" href="@controllers.routes.SaUserController.saUser.url">@Messages("calc.base.button.continue")</a>
         </br>
     }
 }

--- a/app/views/calculation/resident/properties/summary/finalSummary.scala.html
+++ b/app/views/calculation/resident/properties/summary/finalSummary.scala.html
@@ -103,7 +103,7 @@
     </br>
 
     @if(taxYear.isValidYear) {
-        <a class="govuk-button" href="@controllers.routes.SaUserController.saUser.url">@Messages("calc.base.button.continue")</a>
+        <a id="continue-button" class="govuk-button" href="@controllers.routes.SaUserController.saUser.url">@Messages("calc.base.button.continue")</a>
         </br>
     }
 }

--- a/app/views/calculation/resident/properties/summary/gainSummary.scala.html
+++ b/app/views/calculation/resident/properties/summary/gainSummary.scala.html
@@ -74,7 +74,7 @@
     </br>
 
     @if(taxYear.isValidYear) {
-        <a class="govuk-button" href="@controllers.routes.SaUserController.saUser.url">@Messages("calc.base.button.continue")</a>
+        <a id="continue-button" class="govuk-button" href="@controllers.routes.SaUserController.saUser.url">@Messages("calc.base.button.continue")</a>
         </br>
     }
 }

--- a/app/views/calculation/resident/properties/whatNext/whatNextNonSaGain.scala.html
+++ b/app/views/calculation/resident/properties/whatNext/whatNextNonSaGain.scala.html
@@ -35,6 +35,7 @@
 
     @govukButton(Button(
         href = Some(iFormUrl),
+        attributes = Map("id" -> "report-now-button"),
         content = Text(Messages("calc.resident.whatNextNonSa.gain.reportNow"))
     ))
 

--- a/app/views/calculation/resident/properties/whatNext/whatNextSaGain.scala.html
+++ b/app/views/calculation/resident/properties/whatNext/whatNextSaGain.scala.html
@@ -43,6 +43,7 @@
 
     @govukButton(Button(
         href = Some(iFormUrl),
+        attributes = Map("id" -> "report-now-button"),
         content = Text(Messages("calc.whatToDoNext.reportNow"))
     ))
 

--- a/test/views/resident/PersonalAllowanceViewSpec.scala
+++ b/test/views/resident/PersonalAllowanceViewSpec.scala
@@ -219,17 +219,19 @@ class PersonalAllowanceViewSpec extends CommonPlaySpec with WithCommonFakeApplic
       lazy val h1Tag = doc.select("H1")
 
       val nextTaxYear = await(DateAsset.getYearAfterCurrentTaxYear)
+      val nextTaxYearModel = TaxYearModel(nextTaxYear, true, "2016/17")
+      val nextYearString = s"${nextTaxYearModel.startYear} to ${nextTaxYearModel.endYear}"
 
       s"have a title ${messages.question(s"$nextTaxYear")}" in {
-        doc.title() shouldBe messages.title("2023 to 2024")
+        doc.title() shouldBe messages.title(nextYearString)
       }
 
       s"have the page heading '${messages.question(s"$nextTaxYear")}'" in {
-        h1Tag.text shouldBe messages.question("2023 to 2024")
+        h1Tag.text shouldBe messages.question(nextYearString)
       }
 
       s"have a legend for an input with text ${messages.question(s"$nextTaxYear")}" in {
-        doc.body.getElementsByClass("govuk-heading-xl").text() shouldEqual messages.question("2023 to 2024")
+        doc.body.getElementsByClass("govuk-heading-xl").text() shouldEqual messages.question(nextYearString)
       }
     }
 

--- a/test/views/resident/properties/deductions/PropertyLivedInViewSpec.scala
+++ b/test/views/resident/properties/deductions/PropertyLivedInViewSpec.scala
@@ -170,7 +170,7 @@ class PropertyLivedInViewSpec extends CommonPlaySpec with WithCommonFakeApplicat
         button.hasAttr("id") shouldEqual true
       }
 
-      "has id equal to continue-button" in {
+      "has id equal to submit" in {
         button.attr("id") shouldEqual "submit"
       }
 

--- a/test/views/resident/properties/gain/OwnerBeforeLegislationStartViewSpec.scala
+++ b/test/views/resident/properties/gain/OwnerBeforeLegislationStartViewSpec.scala
@@ -169,7 +169,7 @@ class OwnerBeforeLegislationStartViewSpec extends CommonPlaySpec with WithCommon
         button.hasAttr("id") shouldEqual true
       }
 
-      "has id equal to continue-button" in {
+      "has id equal to submit" in {
         button.attr("id") shouldEqual "submit"
       }
 

--- a/test/views/resident/properties/gain/SellForLessViewSpec.scala
+++ b/test/views/resident/properties/gain/SellForLessViewSpec.scala
@@ -176,7 +176,7 @@ class SellForLessViewSpec extends CommonPlaySpec with WithCommonFakeApplication 
         button.hasAttr("id") shouldEqual true
       }
 
-      "has id equal to continue-button" in {
+      "has id equal to submit" in {
         button.attr("id") shouldEqual "submit"
       }
 


### PR DESCRIPTION
# DL-9854 - Added continue button IDs

ATs for DL-9854 used `.govuk-button` to select continue button, changed to `#continue-button`.

## Checklist

 - [ ]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [ ]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
