### PR TITLE
DL-12067 fixed unintended BigDecimal behaviour

### DIFF
--- a/app/common/Transformers.scala
+++ b/app/common/Transformers.scala
@@ -25,9 +25,8 @@ object Transformers {
     case Failure(_) => BigDecimal(0)
   }
 
-
   val bigDecimalToString: BigDecimal => String = (input) => input.scale match {
-    case 1 => input.setScale(2).toString()
+    case scale if scale < 2 && scale != 0 => input.setScale(2).toString()
     case _ => input.toString
   }
 

--- a/app/constructors/resident/properties/CalculateRequestConstructor.scala
+++ b/app/constructors/resident/properties/CalculateRequestConstructor.scala
@@ -38,18 +38,18 @@ object CalculateRequestConstructor {
   }
 
   def totalGainRequestString (answers: YourAnswersSummaryModel): String = {
-      s"?disposalValue=${determineDisposalValueToUse(answers)}" +
-      s"&disposalCosts=${answers.disposalCosts}" +
-      s"&acquisitionValue=${determineAcquisitionValueToUse(answers)}" +
-      s"&acquisitionCosts=${answers.acquisitionCosts}" +
-      s"&improvements=${answers.improvements}" +
+      s"?disposalValue=${determineDisposalValueToUse(answers).toDouble}" +
+      s"&disposalCosts=${answers.disposalCosts.toDouble}" +
+      s"&acquisitionValue=${determineAcquisitionValueToUse(answers).toDouble}" +
+      s"&acquisitionCosts=${answers.acquisitionCosts.toDouble}" +
+      s"&improvements=${answers.improvements.toDouble}" +
       s"&disposalDate=${answers.disposalDate.format(requestFormatter)}"
   }
 
   def prrValue(answers: ChargeableGainAnswers): Map[String, String] = {
     (answers.propertyLivedInModel, answers.privateResidenceReliefModel) match {
       case (Some(x), Some(y)) if x.livedInProperty && y.isClaiming =>
-        Map("prrValue" -> answers.privateResidenceReliefValueModel.get.amount.toString)
+        Map("prrValue" -> answers.privateResidenceReliefValueModel.get.amount.toDouble.toString)
       case _ =>
         Map.empty
     }
@@ -58,7 +58,7 @@ object CalculateRequestConstructor {
   def lettingReliefs(answers: ChargeableGainAnswers): Map[String, String] = {
     (answers.propertyLivedInModel, answers.privateResidenceReliefModel, answers.lettingsReliefModel) match {
       case (Some(x), Some(y), Some(z)) if x.livedInProperty && y.isClaiming && z.isClaiming =>
-        Map("lettingReliefs" -> answers.lettingsReliefValueModel.get.amount.toString)
+        Map("lettingReliefs" -> answers.lettingsReliefValueModel.get.amount.toDouble.toString)
       case _ =>
         Map.empty
     }
@@ -67,7 +67,7 @@ object CalculateRequestConstructor {
   def broughtForwardLosses(answers: ChargeableGainAnswers): Map[String, String] = {
     answers.broughtForwardModel match {
       case (Some(x)) if x.option =>
-        Map("broughtForwardLosses" -> answers.broughtForwardValueModel.get.amount.toString)
+        Map("broughtForwardLosses" -> answers.broughtForwardValueModel.get.amount.toDouble.toString)
       case _ =>
         Map.empty
     }
@@ -79,11 +79,11 @@ object CalculateRequestConstructor {
     }
 
   def chargeableGainRequestString(answers: ChargeableGainAnswers, maxAEA: BigDecimal): String = {
-    s"${toQS(prrValue(answers) ++ lettingReliefs(answers) ++ broughtForwardLosses(answers)) + "&annualExemptAmount=" + maxAEA}"
+    s"${toQS(prrValue(answers) ++ lettingReliefs(answers) ++ broughtForwardLosses(answers)) + "&annualExemptAmount=" + maxAEA.toDouble}"
   }
 
   def incomeAnswersRequestString (deductionsAnswers: ChargeableGainAnswers, answers: IncomeAnswersModel): String = {
-    s"&previousIncome=${answers.currentIncomeModel.get.amount}" +
-    s"&personalAllowance=${answers.personalAllowanceModel.get.amount}"
+    s"&previousIncome=${answers.currentIncomeModel.get.amount.toDouble}" +
+    s"&personalAllowance=${answers.personalAllowanceModel.get.amount.toDouble}"
   }
 }

--- a/app/forms/resident/income/CurrentIncomeForm.scala
+++ b/app/forms/resident/income/CurrentIncomeForm.scala
@@ -37,7 +37,7 @@ object CurrentIncomeForm {
         .verifying(constraintBuilder[String]("calc.resident.currentIncome.invalidAmount", taxYear.startYear, taxYear.endYear) {
           bigDecimalCheck
         })
-        .transform[BigDecimal](stringToBigDecimal, _.toString())
+        .transform[BigDecimal](stringToBigDecimal, bigDecimalToString)
         .verifying(constraintBuilder[BigDecimal]("calc.resident.currentIncome.maximumAmount", taxYear.startYear, taxYear.endYear, MoneyPounds(Constants.maxNumeric, 0).quantity){
           maxCheck
         })

--- a/app/forms/resident/income/PersonalAllowanceForm.scala
+++ b/app/forms/resident/income/PersonalAllowanceForm.scala
@@ -40,7 +40,7 @@ object PersonalAllowanceForm {
         .verifying(constraintBuilder("calc.resident.personalAllowance.invalidAmount", taxYear.startYear, taxYear.endYear) {
           bigDecimalCheck
         })
-        .transform[BigDecimal](stringToBigDecimal, _.toString())
+        .transform[BigDecimal](stringToBigDecimal, bigDecimalToString)
         .verifying(constraintBuilder("calc.resident.personalAllowance.maximumAmount", taxYear.startYear, taxYear.endYear, MoneyPounds(maxPA).quantity) {
           validateMaxPA(maxPA)
         })

--- a/app/forms/resident/income/PreviousTaxableGainsForm.scala
+++ b/app/forms/resident/income/PreviousTaxableGainsForm.scala
@@ -30,7 +30,7 @@ object PreviousTaxableGainsForm {
       "amount" -> text("calc.common.error.mandatoryAmount")
         .verifying("calc.common.error.mandatoryAmount", mandatoryCheck)
         .verifying("calc.common.error.invalidAmount", bigDecimalCheck)
-        .transform[BigDecimal](stringToBigDecimal, _.toString())
+        .transform[BigDecimal](stringToBigDecimal, bigDecimalToString)
         .verifying(maxMonetaryValueConstraint())
         .verifying("calc.common.error.minimumAmount", isPositive)
         .verifying("calc.common.error.invalidAmount", decimalPlacesCheck)

--- a/test/constructors/resident/properties/CalculateRequestConstructorSpec.scala
+++ b/test/constructors/resident/properties/CalculateRequestConstructorSpec.scala
@@ -317,11 +317,11 @@ class CalculateRequestConstructorSpec extends CommonPlaySpec {
         )
 
         val result = CalculateRequestConstructor.totalGainRequestString(answers)
-        result shouldBe s"?disposalValue=4000" +
-          s"&disposalCosts=0" +
-          s"&acquisitionValue=2000" +
-          s"&acquisitionCosts=100" +
-          s"&improvements=10" +
+        result shouldBe s"?disposalValue=4000.0" +
+          s"&disposalCosts=0.0" +
+          s"&acquisitionValue=2000.0" +
+          s"&acquisitionCosts=100.0" +
+          s"&improvements=10.0" +
           s"&disposalDate=2016-02-10"
       }
     }
@@ -343,7 +343,7 @@ class CalculateRequestConstructorSpec extends CommonPlaySpec {
         )
 
         val result = CalculateRequestConstructor.chargeableGainRequestString(answers, BigDecimal(11100))
-        result shouldBe "&annualExemptAmount=11100"
+        result shouldBe "&annualExemptAmount=11100.0"
 
         val prrValueResult = CalculateRequestConstructor.prrValue(answers)
         prrValueResult shouldBe Map()
@@ -369,7 +369,7 @@ class CalculateRequestConstructorSpec extends CommonPlaySpec {
           None
         )
         val result = CalculateRequestConstructor.chargeableGainRequestString(answers, BigDecimal(11100))
-        result shouldBe "&annualExemptAmount=11100"
+        result shouldBe "&annualExemptAmount=11100.0"
 
         val prrValueResult = CalculateRequestConstructor.prrValue(answers)
         prrValueResult shouldBe Map()
@@ -395,16 +395,16 @@ class CalculateRequestConstructorSpec extends CommonPlaySpec {
           Some(LettingsReliefValueModel(4000))
         )
         val result = CalculateRequestConstructor.chargeableGainRequestString(answers, BigDecimal(11100))
-        result should (include("&prrValue=5000") and include("&lettingReliefs=4000") and include("&broughtForwardLosses=2000") and include("&annualExemptAmount=11100"))
+        result should (include("&prrValue=5000.0") and include("&lettingReliefs=4000.0") and include("&broughtForwardLosses=2000.0") and include("&annualExemptAmount=11100.0"))
 
         val prrValueResult = CalculateRequestConstructor.prrValue(answers)
-        prrValueResult shouldBe Map("prrValue" -> "5000")
+        prrValueResult shouldBe Map("prrValue" -> "5000.0")
 
         val lettingReliefsResult = CalculateRequestConstructor.lettingReliefs(answers)
-        lettingReliefsResult shouldBe Map("lettingReliefs" -> "4000")
+        lettingReliefsResult shouldBe Map("lettingReliefs" -> "4000.0")
 
         val broughtForwardLossesResult = CalculateRequestConstructor.broughtForwardLosses(answers)
-        broughtForwardLossesResult shouldBe Map("broughtForwardLosses" -> "2000")
+        broughtForwardLossesResult shouldBe Map("broughtForwardLosses" -> "2000.0")
       }
     }
   }


### PR DESCRIPTION
BigDecimals that are too big and ended in 0.00 were being displayed with scientific notation, this ensures the forms play back user inputs only with 2 decimals or 0, overriding the automatic sci notation. Also updated the backend calls to turn big decimals to doubles first to avoid the same issue and better conform to backend url parameter types.