### PR TITLE
[DLS-9435] forgive commas and pound signs on all currency inputs

### DIFF
--- a/app/common/Transformers.scala
+++ b/app/common/Transformers.scala
@@ -20,6 +20,12 @@ import scala.util.{Failure, Success, Try}
 
 object Transformers {
 
+  val stripCurrencyCharacters: String => String = (input) =>
+    input
+      .trim()
+      .replaceAll(",", "")
+      .replaceAll("£", "")
+
   val stringToBigDecimal: String => BigDecimal = (input) => Try(BigDecimal(input.trim)) match {
     case Success(value) => value
     case Failure(_) => BigDecimal(0)

--- a/app/forms/resident/AcquisitionCostsForm.scala
+++ b/app/forms/resident/AcquisitionCostsForm.scala
@@ -30,6 +30,7 @@ object AcquisitionCostsForm {
   val acquisitionCostsForm = Form(
     mapping(
       "amount" -> text("calc.resident.acquisitionCosts.mandatoryAmount")
+        .transform(stripCurrencyCharacters, stripCurrencyCharacters)
         .verifying("calc.resident.acquisitionCosts.mandatoryAmount", mandatoryCheck)
         .verifying("calc.resident.acquisitionCosts.invalidAmount", bigDecimalCheck)
         .transform[BigDecimal](stringToBigDecimal, bigDecimalToString)

--- a/app/forms/resident/AcquisitionValueForm.scala
+++ b/app/forms/resident/AcquisitionValueForm.scala
@@ -30,6 +30,7 @@ object AcquisitionValueForm {
   val acquisitionValueForm = Form(
     mapping(
       "amount" -> text("calc.resident.acquisitionValue.mandatoryAmount")
+        .transform(stripCurrencyCharacters, stripCurrencyCharacters)
         .verifying("calc.resident.acquisitionValue.mandatoryAmount", mandatoryCheck)
         .verifying("calc.resident.acquisitionValue.invalidAmount", bigDecimalCheck)
         .transform[BigDecimal](stringToBigDecimal, bigDecimalToString)

--- a/app/forms/resident/DisposalCostsForm.scala
+++ b/app/forms/resident/DisposalCostsForm.scala
@@ -30,6 +30,7 @@ object DisposalCostsForm {
   val disposalCostsForm = Form(
     mapping(
       "amount" -> text("calc.resident.disposalCosts.mandatoryAmount")
+        .transform(stripCurrencyCharacters, stripCurrencyCharacters)
         .verifying("calc.resident.disposalCosts.mandatoryAmount", mandatoryCheck)
         .verifying("calc.resident.disposalCosts.invalidAmount", bigDecimalCheck)
         .transform[BigDecimal](stringToBigDecimal, bigDecimalToString)

--- a/app/forms/resident/DisposalValueForm.scala
+++ b/app/forms/resident/DisposalValueForm.scala
@@ -30,6 +30,7 @@ object DisposalValueForm {
   val disposalValueForm = Form(
     mapping(
       "amount" -> text("calc.resident.disposal.value.mandatoryAmount")
+        .transform(stripCurrencyCharacters, stripCurrencyCharacters)
         .verifying("calc.resident.disposal.value.mandatoryAmount", mandatoryCheck)
         .verifying("calc.resident.disposal.value.invalidAmount", bigDecimalCheck)
         .transform[BigDecimal](stringToBigDecimal, bigDecimalToString)

--- a/app/forms/resident/LossesBroughtForwardValueForm.scala
+++ b/app/forms/resident/LossesBroughtForwardValueForm.scala
@@ -30,6 +30,7 @@ object LossesBroughtForwardValueForm {
   def lossesBroughtForwardValueForm(taxYear: TaxYearModel):Form[LossesBroughtForwardValueModel] = Form(
     mapping(
       "amount" -> text("calc.resident.lossesBroughtForward.errorSelect")
+        .transform(stripCurrencyCharacters, stripCurrencyCharacters)
         .verifying(constraintBuilder[String]("calc.resident.lossesBroughtForwardValue.mandatoryAmount", taxYear.startYear, taxYear.endYear) {
           mandatoryCheck
         })

--- a/app/forms/resident/WorthWhenInheritedForm.scala
+++ b/app/forms/resident/WorthWhenInheritedForm.scala
@@ -30,6 +30,7 @@ object WorthWhenInheritedForm {
   val worthWhenInheritedForm = Form(
     mapping(
       "amount" -> text("calc.resident.properties.worthWhenInherited.mandatoryAmount")
+        .transform(stripCurrencyCharacters, stripCurrencyCharacters)
         .verifying("calc.resident.properties.worthWhenInherited.mandatoryAmount", mandatoryCheck)
         .verifying("calc.resident.properties.worthWhenInherited.invalidAmount", bigDecimalCheck)
         .transform[BigDecimal](stringToBigDecimal, bigDecimalToString)

--- a/app/forms/resident/WorthWhenSoldForLessForm.scala
+++ b/app/forms/resident/WorthWhenSoldForLessForm.scala
@@ -30,6 +30,7 @@ object WorthWhenSoldForLessForm {
   val worthWhenSoldForLessForm = Form(
     mapping(
       "amount" -> text("calc.resident.properties.worthWhenSoldForLess.mandatoryAmount")
+        .transform(stripCurrencyCharacters, stripCurrencyCharacters)
         .verifying("calc.resident.properties.worthWhenSoldForLess.mandatoryAmount", mandatoryCheck)
         .verifying("calc.resident.properties.worthWhenSoldForLess.invalidAmount", bigDecimalCheck)
         .transform[BigDecimal](stringToBigDecimal, bigDecimalToString)

--- a/app/forms/resident/income/CurrentIncomeForm.scala
+++ b/app/forms/resident/income/CurrentIncomeForm.scala
@@ -31,6 +31,7 @@ object CurrentIncomeForm {
   def currentIncomeForm(taxYear: TaxYearModel):Form[CurrentIncomeModel] = Form(
     mapping(
       "amount" -> text("calc.resident.currentIncome.mandatoryAmount", taxYear.startYear, taxYear.endYear)
+        .transform(stripCurrencyCharacters, stripCurrencyCharacters)
         .verifying(constraintBuilder[String]("calc.resident.currentIncome.mandatoryAmount", taxYear.startYear, taxYear.endYear){
           mandatoryCheck
         })

--- a/app/forms/resident/income/PersonalAllowanceForm.scala
+++ b/app/forms/resident/income/PersonalAllowanceForm.scala
@@ -34,6 +34,7 @@ object PersonalAllowanceForm {
   def personalAllowanceForm(taxYear: TaxYearModel, maxPA: BigDecimal = BigDecimal(0)): Form[PersonalAllowanceModel] = Form(
     mapping(
       "amount" -> text("calc.resident.personalAllowance.mandatoryAmount", taxYear.startYear, taxYear.endYear)
+        .transform(stripCurrencyCharacters, stripCurrencyCharacters)
         .verifying(constraintBuilder("calc.resident.personalAllowance.mandatoryAmount", taxYear.startYear, taxYear.endYear) {
           mandatoryCheck
         })

--- a/app/forms/resident/income/PreviousTaxableGainsForm.scala
+++ b/app/forms/resident/income/PreviousTaxableGainsForm.scala
@@ -28,6 +28,7 @@ object PreviousTaxableGainsForm {
   val previousTaxableGainsForm = Form(
     mapping(
       "amount" -> text("calc.common.error.mandatoryAmount")
+        .transform(stripCurrencyCharacters, stripCurrencyCharacters)
         .verifying("calc.common.error.mandatoryAmount", mandatoryCheck)
         .verifying("calc.common.error.invalidAmount", bigDecimalCheck)
         .transform[BigDecimal](stringToBigDecimal, bigDecimalToString)

--- a/app/forms/resident/properties/ImprovementsForm.scala
+++ b/app/forms/resident/properties/ImprovementsForm.scala
@@ -30,6 +30,7 @@ object ImprovementsForm {
   val improvementsForm = Form(
     mapping(
       "amount" -> text("calc.resident.properties.improvements.mandatoryAmount")
+        .transform(stripCurrencyCharacters, stripCurrencyCharacters)
         .verifying("calc.resident.properties.improvements.mandatoryAmount", mandatoryCheck)
         .verifying("calc.resident.properties.improvements.invalidAmount", bigDecimalCheck)
         .transform[BigDecimal](stringToBigDecimal, bigDecimalToString)

--- a/app/forms/resident/properties/LettingsReliefValueForm.scala
+++ b/app/forms/resident/properties/LettingsReliefValueForm.scala
@@ -40,6 +40,7 @@ object LettingsReliefValueForm {
   def lettingsReliefValueForm(gain: BigDecimal, prrValue: BigDecimal): Form[LettingsReliefValueModel] =
     Form(mapping(
       "amount" -> text("calc.resident.lettingsReliefValue.mandatoryAmount")
+        .transform(stripCurrencyCharacters, stripCurrencyCharacters)
         .verifying("calc.resident.lettingsReliefValue.mandatoryAmount", mandatoryCheck)
         .verifying("calc.resident.lettingsReliefValue.invalidAmount", bigDecimalCheck)
         .transform[BigDecimal](stringToBigDecimal, bigDecimalToString)

--- a/app/forms/resident/properties/PrivateResidenceReliefValueForm.scala
+++ b/app/forms/resident/properties/PrivateResidenceReliefValueForm.scala
@@ -29,6 +29,7 @@ object PrivateResidenceReliefValueForm {
   def privateResidenceReliefValueForm(gain: BigDecimal): Form[PrivateResidenceReliefValueModel] = Form(
     mapping(
       "amount" -> text("calc.resident.properties.privateResidenceReliefValue.mandatoryAmount")
+        .transform(stripCurrencyCharacters, stripCurrencyCharacters)
         .verifying("calc.resident.properties.privateResidenceReliefValue.mandatoryAmount", mandatoryCheck)
         .verifying("calc.resident.properties.privateResidenceReliefValue.invalidAmount", bigDecimalCheck)
         .transform[BigDecimal](stringToBigDecimal, bigDecimalToString)

--- a/app/forms/resident/properties/ValueBeforeLegislationStartForm.scala
+++ b/app/forms/resident/properties/ValueBeforeLegislationStartForm.scala
@@ -30,6 +30,7 @@ object ValueBeforeLegislationStartForm {
   val valueBeforeLegislationStartForm = Form(
     mapping(
       "amount" -> text("calc.resident.properties.valueBeforeLegislationStart.mandatoryAmount")
+        .transform(stripCurrencyCharacters, stripCurrencyCharacters)
         .verifying("calc.resident.properties.valueBeforeLegislationStart.mandatoryAmount", mandatoryCheck)
         .verifying("calc.resident.properties.valueBeforeLegislationStart.invalidAmount", bigDecimalCheck)
         .transform[BigDecimal](stringToBigDecimal, bigDecimalToString)

--- a/app/forms/resident/properties/WorthWhenBoughtForLessForm.scala
+++ b/app/forms/resident/properties/WorthWhenBoughtForLessForm.scala
@@ -30,6 +30,7 @@ object WorthWhenBoughtForLessForm {
   val worthWhenBoughtForLessForm = Form(
     mapping(
       "amount" -> text("calc.resident.properties.worthWhenBoughtForLess.mandatoryAmount")
+        .transform(stripCurrencyCharacters, stripCurrencyCharacters)
         .verifying("calc.resident.properties.worthWhenBoughtForLess.mandatoryAmount", mandatoryCheck)
         .verifying("calc.resident.properties.worthWhenBoughtForLess.invalidAmount", bigDecimalCheck)
         .transform[BigDecimal](stringToBigDecimal, bigDecimalToString)

--- a/app/forms/resident/properties/WorthWhenGaveAwayForm.scala
+++ b/app/forms/resident/properties/WorthWhenGaveAwayForm.scala
@@ -30,6 +30,7 @@ object WorthWhenGaveAwayForm {
   val worthWhenGaveAwayForm = Form(
     mapping(
       "amount" -> text("calc.resident.properties.worthWhenGaveAway.mandatoryAmount")
+        .transform(stripCurrencyCharacters, stripCurrencyCharacters)
         .verifying("calc.resident.properties.worthWhenGaveAway.mandatoryAmount", mandatoryCheck)
         .verifying("calc.resident.properties.worthWhenGaveAway.invalidAmount", bigDecimalCheck)
         .transform[BigDecimal](stringToBigDecimal, bigDecimalToString)

--- a/app/forms/resident/properties/gain/WorthWhenGiftedForm.scala
+++ b/app/forms/resident/properties/gain/WorthWhenGiftedForm.scala
@@ -30,6 +30,7 @@ object WorthWhenGiftedForm {
   val worthWhenGiftedForm = Form(
     mapping(
       "amount" -> text("calc.resident.properties.worthWhenGifted.mandatoryAmount")
+        .transform(stripCurrencyCharacters, stripCurrencyCharacters)
         .verifying("calc.resident.properties.worthWhenGifted.mandatoryAmount", mandatoryCheck)
         .verifying("calc.resident.properties.worthWhenGifted.invalidAmount", bigDecimalCheck)
         .transform[BigDecimal](stringToBigDecimal, bigDecimalToString)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 resolvers += "HMRC-open-artefacts-maven" at "https://open.artefacts.tax.service.gov.uk/maven2"
 resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.14.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.15.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.2.0")
 

--- a/test/common/TransformersSpec.scala
+++ b/test/common/TransformersSpec.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package common
+
+class TransformersSpec extends CommonPlaySpec {
+
+  "stripCurrencyCharacters" should {
+    "return a cleaned currency amount" when {
+      "the transform is applied to an amount with commas and pound signs" in {
+        val result = Transformers.stripCurrencyCharacters("£1,999")
+        result shouldBe "1999"
+      }
+      "the transform is applied to an amount with commas" in {
+        val result = Transformers.stripCurrencyCharacters("1,999")
+        result shouldBe "1999"
+      }
+      "the transform is applied to an amount with pound signs" in {
+        val result = Transformers.stripCurrencyCharacters("£1999")
+        result shouldBe "1999"
+      }
+    }
+  }
+
+  "stringToBigDecimal" should {
+    "return a BigDecimal" when {
+      "the transformation fails" in {
+        val result = Transformers.stringToBigDecimal("1000")
+        result shouldBe BigDecimal(1000)
+      }
+    }
+
+    "return zero as a BigDecimal" when {
+      "the transformation fails" in {
+        val result = Transformers.stringToBigDecimal("FAIL")
+        result shouldBe BigDecimal(0)
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
# DLS-9435 forgive commas and pound signs on all currency inputs

**New feature**

This will mean users who enter or copy and paste currency amounts with commas and/or pound signs in them will not get errors because of that.

## Checklist

 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date
