### PR TITLE
[DLS-9437] Replace custom CYA styles

### DIFF
--- a/app/assets/stylesheets/cgt-calculator-resident-properties.css
+++ b/app/assets/stylesheets/cgt-calculator-resident-properties.css
@@ -1,16 +1,3 @@
-
-.govuk-summary-list__key {
-    width: 70%;
-}
-
-.govuk-summary-list__value {
-    width: 20%;
-}
-
-.govuk-summary-list__actions {
-    width: 10%
-}
-
 .cgt-for-print {
     display: none;
 }

--- a/app/views/playHelpers/resident/summaryDateRowHelper.scala.html
+++ b/app/views/playHelpers/resident/summaryDateRowHelper.scala.html
@@ -25,7 +25,7 @@
 
 @if(displayLink && link.isDefined) {
     <div id="@rowId" class="govuk-summary-list__row">
-        <dt id="@{rowId}-question" class="govuk-summary-list__key">
+        <dt id="@{rowId}-question" class="govuk-summary-list__key govuk-!-width-one-half">
             @question
         </dt>
         <dd id="@{rowId}-date" class="govuk-summary-list__value">

--- a/app/views/playHelpers/resident/summaryNumericRowHelper.scala.html
+++ b/app/views/playHelpers/resident/summaryNumericRowHelper.scala.html
@@ -28,7 +28,7 @@
 
     @if(link.isDefined && displayLink) {
         <div id="@rowId" class="govuk-summary-list__row">
-            <dt id="@{rowId}-question" class="govuk-summary-list__key">
+            <dt id="@{rowId}-question" class="govuk-summary-list__key govuk-!-width-one-half">
                 @question
             </dt>
             <dd id="@{rowId}-amount" class="govuk-summary-list__value">

--- a/app/views/playHelpers/resident/summaryOptionRowHelper.scala.html
+++ b/app/views/playHelpers/resident/summaryOptionRowHelper.scala.html
@@ -20,7 +20,7 @@
 
 @if(link.isDefined && displayLink) {
     <div id="@rowId" class="govuk-summary-list__row">
-        <dt id="@{rowId}-question" class="govuk-summary-list__key">
+        <dt id="@{rowId}-question" class="govuk-summary-list__key govuk-!-width-one-half">
             @question
         </dt>
         <dd id="@{rowId}-option" class="govuk-summary-list__value">

--- a/app/views/playHelpers/resident/summaryTextRowHelper.scala.html
+++ b/app/views/playHelpers/resident/summaryTextRowHelper.scala.html
@@ -20,7 +20,7 @@
 
     @if(displayLink && link.isDefined) {
         <div id="@rowId" class="govuk-summary-list__row">
-            <dt id="@{rowId}-question" class="govuk-summary-list__key">
+            <dt id="@{rowId}-question" class="govuk-summary-list__key govuk-!-width-one-half">
                 @question
             </dt>
             <dd id="@{rowId}-option" class="govuk-summary-list__value">


### PR DESCRIPTION
# DLS-9437 Replace custom summary list styles

**P1 layout fix**

The CYA page uses some additional custom styles which affect the layout of the page at smaller viewports. In particular the user data is heavily width-constrained causing wrapping when it is not necessary.

## Checklist

 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date
