### PR TITLE
DLS-9341 Clean up warnings

### DIFF
--- a/app/common/Dates.scala
+++ b/app/common/Dates.scala
@@ -24,10 +24,10 @@ import scala.concurrent.Future
 
 object Dates {
 
-  val taxYearEnd = "04-05"
-  val formatter = DateTimeFormatter.ofPattern("d/M/uuuu").withResolverStyle(ResolverStyle.STRICT)
-  val requestFormatter = DateTimeFormatter.ofPattern("uuuu-MM-dd").withResolverStyle(ResolverStyle.STRICT)
-  val datePageFormatNoZero = DateTimeFormatter.ofPattern("d MMMM uuuu").withResolverStyle(ResolverStyle.STRICT)
+  val taxYearEnd: String = "04-05"
+  val formatter: DateTimeFormatter = DateTimeFormatter.ofPattern("d/M/uuuu").withResolverStyle(ResolverStyle.STRICT)
+  val requestFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("uuuu-MM-dd").withResolverStyle(ResolverStyle.STRICT)
+  val datePageFormatNoZero: DateTimeFormatter = DateTimeFormatter.ofPattern("d MMMM uuuu").withResolverStyle(ResolverStyle.STRICT)
 
   def constructDate(day: Int, month: Int, year: Int): LocalDate = LocalDate.parse(s"$day/$month/$year", formatter)
 

--- a/app/controllers/DeductionsController.scala
+++ b/app/controllers/DeductionsController.scala
@@ -73,7 +73,7 @@ class DeductionsController @Inject()(
   def answerSummary(implicit request: Request [_]): Future[YourAnswersSummaryModel] = sessionCacheService.getPropertyGainAnswers(request)
 
   //################# Property Lived In Actions #############################
-  val propertyLivedIn: Action[AnyContent] = ValidateSession.async { implicit request =>
+  def propertyLivedIn: Action[AnyContent] = ValidateSession.async { implicit request =>
 
     val backLink = Some(controllers.routes.GainController.improvements.toString)
 
@@ -83,7 +83,7 @@ class DeductionsController @Inject()(
     }
   }
 
-  val submitPropertyLivedIn: Action[AnyContent] = ValidateSession.async { implicit request =>
+  def submitPropertyLivedIn: Action[AnyContent] = ValidateSession.async { implicit request =>
 
     lazy val backLink = Some(routes.GainController.improvements.url)
 
@@ -108,14 +108,14 @@ class DeductionsController @Inject()(
 
 
   //########## Private Residence Relief Actions ##############
-  val privateResidenceRelief: Action[AnyContent] = ValidateSession.async { implicit request =>
+  def privateResidenceRelief: Action[AnyContent] = ValidateSession.async { implicit request =>
     sessionCacheService.fetchAndGetFormData[PrivateResidenceReliefModel](keystoreKeys.privateResidenceRelief).map {
       case Some(data) => Ok(privateResidenceReliefView(privateResidenceReliefForm.fill(data)))
       case _ => Ok(privateResidenceReliefView(privateResidenceReliefForm))
     }
   }
 
-  val submitPrivateResidenceRelief: Action[AnyContent] = ValidateSession.async { implicit request =>
+  def submitPrivateResidenceRelief: Action[AnyContent] = ValidateSession.async { implicit request =>
 
     def errorAction(errors: Form[PrivateResidenceReliefModel]) = Future.successful(BadRequest(privateResidenceReliefView(errors)))
 
@@ -136,7 +136,7 @@ class DeductionsController @Inject()(
 
 
   //########## Private Residence Relief Value Actions ##############
-  val privateResidenceReliefValue: Action[AnyContent] = ValidateSession.async { implicit request =>
+  def privateResidenceReliefValue: Action[AnyContent] = ValidateSession.async { implicit request =>
 
     def routeRequest(totalGain: BigDecimal) = {
       sessionCacheService.fetchAndGetFormData[PrivateResidenceReliefValueModel](keystoreKeys.prrValue).map {
@@ -152,7 +152,7 @@ class DeductionsController @Inject()(
     } yield route
   }
 
-  val submitPrivateResidenceReliefValue: Action[AnyContent] = ValidateSession.async { implicit request =>
+  def submitPrivateResidenceReliefValue: Action[AnyContent] = ValidateSession.async { implicit request =>
 
     def successAction(model: PrivateResidenceReliefValueModel) = {
       sessionCacheService.saveFormData[PrivateResidenceReliefValueModel](keystoreKeys.prrValue, model).map (_ =>
@@ -176,14 +176,14 @@ class DeductionsController @Inject()(
   //############## Lettings Relief Actions ##################
   private lazy val lettingsReliefBackUrl = routes.DeductionsController.privateResidenceReliefValue.url
 
-  val lettingsRelief: Action[AnyContent] = ValidateSession.async { implicit request =>
+  def lettingsRelief: Action[AnyContent] = ValidateSession.async { implicit request =>
     sessionCacheService.fetchAndGetFormData[LettingsReliefModel](keystoreKeys.lettingsRelief).map {
       case Some(data) => Ok(lettingsReliefView(lettingsReliefForm.fill(data), Some(lettingsReliefBackUrl)))
       case None => Ok(lettingsReliefView(lettingsReliefForm, Some(lettingsReliefBackUrl)))
     }
   }
 
-  val submitLettingsRelief: Action[AnyContent] = ValidateSession.async { implicit request =>
+  def submitLettingsRelief: Action[AnyContent] = ValidateSession.async { implicit request =>
 
     def errorAction(form: Form[LettingsReliefModel]) = {
       Future.successful(BadRequest(lettingsReliefView(form, Some(lettingsReliefBackUrl))))
@@ -222,7 +222,7 @@ class DeductionsController @Inject()(
   }
 
   //################# Lettings Relief Value Input Actions ########################
-  val lettingsReliefValue: Action[AnyContent] = ValidateSession.async { implicit request =>
+  def lettingsReliefValue: Action[AnyContent] = ValidateSession.async { implicit request =>
 
     def routeRequest(totalGain: BigDecimal, prrValue: BigDecimal): Future[Result] = {
       sessionCacheService.fetchAndGetFormData[LettingsReliefValueModel](keystoreKeys.lettingsReliefValue).map {
@@ -239,7 +239,7 @@ class DeductionsController @Inject()(
     } yield route).recoverToStart()
   }
 
-  val submitLettingsReliefValue: Action[AnyContent] = ValidateSession.async { implicit request =>
+  def submitLettingsReliefValue: Action[AnyContent] = ValidateSession.async { implicit request =>
 
     def routeRequest(totalGain: BigDecimal, prrValue: BigDecimal) = {
       lettingsReliefValueForm(totalGain, prrValue).bindFromRequest().fold(
@@ -272,7 +272,7 @@ class DeductionsController @Inject()(
     } yield backUrl
   }
 
-  val lossesBroughtForward: Action[AnyContent] = ValidateSession.async { implicit request =>
+  def lossesBroughtForward: Action[AnyContent] = ValidateSession.async { implicit request =>
 
     def routeRequest(backLinkUrl: String, taxYear: TaxYearModel): Future[Result] = {
       sessionCacheService.fetchAndGetFormData[LossesBroughtForwardModel](keystoreKeys.lossesBroughtForward).map {
@@ -315,7 +315,7 @@ class DeductionsController @Inject()(
     }
   }
 
-  val submitLossesBroughtForward: Action[AnyContent] = ValidateSession.async { implicit request =>
+  def submitLossesBroughtForward: Action[AnyContent] = ValidateSession.async { implicit request =>
 
     def routeRequest(backUrl: String, taxYearModel: TaxYearModel): Future[Result] = {
       lossesBroughtForwardForm(taxYearModel).bindFromRequest().fold(
@@ -350,7 +350,7 @@ class DeductionsController @Inject()(
   private lazy val lossesBroughtForwardValueBackLink = routes.DeductionsController.lossesBroughtForward.url
   private lazy val lossesBroughtForwardValuePostAction = routes.DeductionsController.submitLossesBroughtForwardValue
 
-  val lossesBroughtForwardValue: Action[AnyContent] = ValidateSession.async { implicit request =>
+  def lossesBroughtForwardValue: Action[AnyContent] = ValidateSession.async { implicit request =>
 
     def retrieveKeystoreData(taxYear: TaxYearModel): Future[Form[LossesBroughtForwardValueModel]] = {
       sessionCacheService.fetchAndGetFormData[LossesBroughtForwardValueModel](keystoreKeys.lossesBroughtForwardValue).map {
@@ -378,7 +378,7 @@ class DeductionsController @Inject()(
     } yield route).recoverToStart()
   }
 
-  val submitLossesBroughtForwardValue: Action[AnyContent] = ValidateSession.async { implicit request =>
+  def submitLossesBroughtForwardValue: Action[AnyContent] = ValidateSession.async { implicit request =>
 
     def routeRequest(taxYear: TaxYearModel): Future[Result] = {
       lossesBroughtForwardValueForm(taxYear).bindFromRequest().fold(

--- a/app/controllers/GainController.scala
+++ b/app/controllers/GainController.scala
@@ -92,7 +92,7 @@ class GainController @Inject()(
   }
 
   //################# Disposal Date Actions ####################
-  val disposalDate: Action[AnyContent] = Action.async { implicit request =>
+  def disposalDate: Action[AnyContent] = Action.async { implicit request =>
     if (request.session.get(SessionKeys.sessionId).isEmpty) {
       val sessionId = UUID.randomUUID.toString
       Future.successful(Ok(disposalDateView(disposalDateForm())).withSession(request.session + (SessionKeys.sessionId -> s"session-$sessionId")))
@@ -105,7 +105,7 @@ class GainController @Inject()(
     }
   }
 
-  val submitDisposalDate: Action[AnyContent] = ValidateSession.async { implicit request =>
+  def submitDisposalDate: Action[AnyContent] = ValidateSession.async { implicit request =>
 
     def routeRequest(taxYearResult: Option[TaxYearModel]): Future[Result] = {
       if (taxYearResult.isDefined && !taxYearResult.get.isValidYear) Future.successful(Redirect(routes.GainController.outsideTaxYears))
@@ -142,7 +142,7 @@ class GainController @Inject()(
   lazy val sellOrGiveAwayBackUrl = routes.GainController.disposalDate.url
   lazy val sellOrGiveAwayPostAction = controllers.routes.GainController.submitSellOrGiveAway
 
-  val sellOrGiveAway: Action[AnyContent] = ValidateSession.async { implicit request =>
+  def sellOrGiveAway: Action[AnyContent] = ValidateSession.async { implicit request =>
 
     sessionCacheService.fetchAndGetFormData[SellOrGiveAwayModel](keystoreKeys.sellOrGiveAway).map {
       case Some(data) => Ok(sellOrGiveAwayView(sellOrGiveAwayForm.fill(data), Some(sellOrGiveAwayBackUrl), sellOrGiveAwayPostAction))
@@ -150,7 +150,7 @@ class GainController @Inject()(
     }
   }
 
-  val submitSellOrGiveAway: Action[AnyContent] = ValidateSession.async { implicit request =>
+  def submitSellOrGiveAway: Action[AnyContent] = ValidateSession.async { implicit request =>
     sellOrGiveAwayForm.bindFromRequest().fold(
       errors => Future.successful(BadRequest(sellOrGiveAwayView(errors, Some(sellOrGiveAwayBackUrl), sellOrGiveAwayPostAction))),
       success => {
@@ -165,7 +165,7 @@ class GainController @Inject()(
   }
 
   //################ Who Did You Give It To Actions ######################
-  val whoDidYouGiveItTo: Action[AnyContent] = ValidateSession.async { implicit request =>
+  def whoDidYouGiveItTo: Action[AnyContent] = ValidateSession.async { implicit request =>
 
     sessionCacheService.fetchAndGetFormData[WhoDidYouGiveItToModel](keystoreKeys.whoDidYouGiveItTo).map {
       case Some(data) => Ok(whoDidYouGiveItToView(whoDidYouGiveItToForm.fill(data)))
@@ -173,7 +173,7 @@ class GainController @Inject()(
     }
   }
 
-  val submitWhoDidYouGiveItTo: Action[AnyContent] = ValidateSession.async { implicit request =>
+  def submitWhoDidYouGiveItTo: Action[AnyContent] = ValidateSession.async { implicit request =>
     whoDidYouGiveItToForm.bindFromRequest().fold(
       errors => Future.successful(BadRequest(whoDidYouGiveItToView(errors))),
       success => {
@@ -188,7 +188,7 @@ class GainController @Inject()(
   }
 
   //################ No Tax to Pay Actions ######################
-  val noTaxToPay: Action[AnyContent] = ValidateSession.async { implicit request =>
+  def noTaxToPay: Action[AnyContent] = ValidateSession.async { implicit request =>
 
     def isGivenToCharity: Future[Boolean] = {
       sessionCacheService.fetchAndGetFormData[WhoDidYouGiveItToModel](keystoreKeys.whoDidYouGiveItTo).map {
@@ -208,7 +208,7 @@ class GainController @Inject()(
   }
 
   //################ Outside Tax Years Actions ######################
-  val outsideTaxYears: Action[AnyContent] = ValidateSession.async { implicit request =>
+  def outsideTaxYears: Action[AnyContent] = ValidateSession.async { implicit request =>
     (for {
       disposalDate <- sessionCacheService.fetchAndGetFormData[DisposalDateModel](keystoreKeys.disposalDate)
       taxYear <- calcConnector.getTaxYear(s"${disposalDate.get.year}-${disposalDate.get.month}-${disposalDate.get.day}")
@@ -230,14 +230,14 @@ class GainController @Inject()(
   private lazy val worthWhenGaveAwayPostAction = controllers.routes.GainController.submitWorthWhenGaveAway
   private lazy val worthWhenGaveAwayBackLink = Some(controllers.routes.GainController.whoDidYouGiveItTo.toString)
 
-  val worthWhenGaveAway: Action[AnyContent] = ValidateSession.async { implicit request =>
+  def worthWhenGaveAway: Action[AnyContent] = ValidateSession.async { implicit request =>
     sessionCacheService.fetchAndGetFormData[WorthWhenGaveAwayModel](keystoreKeys.worthWhenGaveAway).map {
       case Some(data) => Ok(worthWhenGaveAwayView(worthWhenGaveAwayForm.fill(data), worthWhenGaveAwayBackLink, worthWhenGaveAwayPostAction))
       case None => Ok(worthWhenGaveAwayView(worthWhenGaveAwayForm, worthWhenGaveAwayBackLink, worthWhenGaveAwayPostAction))
     }
   }
 
-  val submitWorthWhenGaveAway: Action[AnyContent] = ValidateSession.async { implicit request =>
+  def submitWorthWhenGaveAway: Action[AnyContent] = ValidateSession.async { implicit request =>
     worthWhenGaveAwayForm.bindFromRequest().fold(
       errors => Future.successful(BadRequest(worthWhenGaveAwayView(errors, worthWhenGaveAwayBackLink, worthWhenGaveAwayPostAction))),
       success => {
@@ -250,7 +250,7 @@ class GainController @Inject()(
   //############## Sell for Less Actions ##################
   lazy val sellForLessBackLink = Some(controllers.routes.GainController.sellOrGiveAway.url)
 
-  val sellForLess: Action[AnyContent] = ValidateSession.async {implicit request =>
+  def sellForLess: Action[AnyContent] = ValidateSession.async {implicit request =>
     sessionCacheService.fetchAndGetFormData[SellForLessModel](keystoreKeys.sellForLess).map{
       case Some(data) => Ok(sellForLessView(sellForLessForm.fill(data), sellForLessBackLink))
       case _ => Ok(sellForLessView(sellForLessForm, sellForLessBackLink))
@@ -276,14 +276,14 @@ class GainController @Inject()(
   }
 
   //################ Disposal Value Actions ######################
-  val disposalValue: Action[AnyContent] = ValidateSession.async { implicit request =>
+  def disposalValue: Action[AnyContent] = ValidateSession.async { implicit request =>
     sessionCacheService.fetchAndGetFormData[DisposalValueModel](keystoreKeys.disposalValue).map {
       case Some(data) => Ok(disposalValueView(disposalValueForm.fill(data)))
       case None => Ok(disposalValueView(disposalValueForm))
     }
   }
 
-  val submitDisposalValue: Action[AnyContent] = ValidateSession.async { implicit request =>
+  def submitDisposalValue: Action[AnyContent] = ValidateSession.async { implicit request =>
     disposalValueForm.bindFromRequest().fold(
       errors => Future.successful(BadRequest(disposalValueView(errors))),
       success => {
@@ -294,14 +294,14 @@ class GainController @Inject()(
   }
 
   //################ Property Worth When Sold For Less Actions ######################
-  val worthWhenSoldForLess: Action[AnyContent] = ValidateSession.async { implicit request =>
+  def worthWhenSoldForLess: Action[AnyContent] = ValidateSession.async { implicit request =>
     sessionCacheService.fetchAndGetFormData[WorthWhenSoldForLessModel](keystoreKeys.worthWhenSoldForLess).map {
       case Some(data) => Ok(worthWhenSoldForLessView(worthWhenSoldForLessForm.fill(data)))
       case _ => Ok(worthWhenSoldForLessView(worthWhenSoldForLessForm))
     }
   }
 
-  val submitWorthWhenSoldForLess: Action[AnyContent] = ValidateSession.async { implicit request =>
+  def submitWorthWhenSoldForLess: Action[AnyContent] = ValidateSession.async { implicit request =>
 
     worthWhenSoldForLessForm.bindFromRequest().fold(
       errors => Future.successful(BadRequest(worthWhenSoldForLessView(errors))),
@@ -319,7 +319,7 @@ class GainController @Inject()(
     case (_, _) => routes.GainController.disposalValue.url
   }
 
-  val disposalCosts: Action[AnyContent] = ValidateSession.async { implicit request =>
+  def disposalCosts: Action[AnyContent] = ValidateSession.async { implicit request =>
 
     def routeRequest(backLink: String) = {
       sessionCacheService.fetchAndGetFormData[DisposalCostsModel](keystoreKeys.disposalCosts).map {
@@ -335,7 +335,7 @@ class GainController @Inject()(
     } yield route).recoverToStart()
   }
 
-  val submitDisposalCosts: Action[AnyContent] = ValidateSession.async { implicit request =>
+  def submitDisposalCosts: Action[AnyContent] = ValidateSession.async { implicit request =>
     def routeRequest(backLink: String) = {
       disposalCostsForm.bindFromRequest().fold(
         errors => Future.successful(BadRequest(disposalCostsView(errors,backLink))),
@@ -354,14 +354,14 @@ class GainController @Inject()(
   }
 
   //################# Owner Before Legislation Start Actions ########################
-  val ownerBeforeLegislationStart: Action[AnyContent] = ValidateSession.async { implicit request =>
+  def ownerBeforeLegislationStart: Action[AnyContent] = ValidateSession.async { implicit request =>
     sessionCacheService.fetchAndGetFormData[OwnerBeforeLegislationStartModel](keystoreKeys.ownerBeforeLegislationStart).map {
       case Some(data) => Ok(ownerBeforeLegislationStartView(ownerBeforeLegislationStartForm.fill(data)))
       case None => Ok(ownerBeforeLegislationStartView(ownerBeforeLegislationStartForm))
     }
   }
 
-  val submitOwnerBeforeLegislationStart: Action[AnyContent] = ValidateSession.async { implicit request =>
+  def submitOwnerBeforeLegislationStart: Action[AnyContent] = ValidateSession.async { implicit request =>
 
     def errorAction(errors: Form[OwnerBeforeLegislationStartModel]) = Future.successful(BadRequest(ownerBeforeLegislationStartView(errors)))
 
@@ -382,14 +382,14 @@ class GainController @Inject()(
 
   //################# Value Before Legislation Start Actions ########################
 
-  val valueBeforeLegislationStart: Action[AnyContent] = ValidateSession.async { implicit request =>
+  def valueBeforeLegislationStart: Action[AnyContent] = ValidateSession.async { implicit request =>
     sessionCacheService.fetchAndGetFormData[ValueBeforeLegislationStartModel](keystoreKeys.valueBeforeLegislationStart).map {
       case Some(data) => Ok(valueBeforeLegislationStartView(valueBeforeLegislationStartForm.fill(data)))
       case None => Ok(valueBeforeLegislationStartView(valueBeforeLegislationStartForm))
     }
   }
 
-  val submitValueBeforeLegislationStart: Action[AnyContent] = ValidateSession.async { implicit request =>
+  def submitValueBeforeLegislationStart: Action[AnyContent] = ValidateSession.async { implicit request =>
     valueBeforeLegislationStartForm.bindFromRequest().fold(
       errors => Future.successful(BadRequest(valueBeforeLegislationStartView(errors))),
       success => {
@@ -403,7 +403,7 @@ class GainController @Inject()(
   lazy val howBecameOwnerBackLink = Some(controllers.routes.GainController.ownerBeforeLegislationStart.url)
   lazy val howBecameOwnerPostAction = controllers.routes.GainController.submitHowBecameOwner
 
-  val howBecameOwner: Action[AnyContent] = ValidateSession.async { implicit request =>
+  def howBecameOwner: Action[AnyContent] = ValidateSession.async { implicit request =>
 
     sessionCacheService.fetchAndGetFormData[HowBecameOwnerModel](keystoreKeys.howBecameOwner).map {
       case Some(data) => Ok(howBecameOwnerView(howBecameOwnerForm.fill(data), howBecameOwnerBackLink, howBecameOwnerPostAction))
@@ -411,7 +411,7 @@ class GainController @Inject()(
     }
   }
 
-  val submitHowBecameOwner: Action[AnyContent] = ValidateSession.async { implicit request =>
+  def submitHowBecameOwner: Action[AnyContent] = ValidateSession.async { implicit request =>
     howBecameOwnerForm.bindFromRequest().fold(
       errors => Future.successful(BadRequest(howBecameOwnerView(errors, howBecameOwnerBackLink, howBecameOwnerPostAction))),
       success => {
@@ -429,14 +429,14 @@ class GainController @Inject()(
   //################# Bought For Less Than Worth Actions ########################
   lazy val boughtForLessThanWorthBackLink = Some(controllers.routes.GainController.howBecameOwner.url)
 
-  val boughtForLessThanWorth: Action[AnyContent] = ValidateSession.async {implicit request =>
+  def boughtForLessThanWorth: Action[AnyContent] = ValidateSession.async {implicit request =>
     sessionCacheService.fetchAndGetFormData[BoughtForLessThanWorthModel](keystoreKeys.boughtForLessThanWorth).map {
       case Some(data) => Ok(buyForLessView(boughtForLessThanWorthForm.fill(data), boughtForLessThanWorthBackLink))
       case _ => Ok(buyForLessView(boughtForLessThanWorthForm, boughtForLessThanWorthBackLink))
     }
   }
 
-  val submitBoughtForLessThanWorth: Action[AnyContent] = ValidateSession.async { implicit request =>
+  def submitBoughtForLessThanWorth: Action[AnyContent] = ValidateSession.async { implicit request =>
     def errorAction(errors: Form[BoughtForLessThanWorthModel]) = Future.successful(BadRequest(buyForLessView(errors, boughtForLessThanWorthBackLink)))
 
     def routeRequest(model: BoughtForLessThanWorthModel) = {
@@ -459,14 +459,14 @@ class GainController @Inject()(
   lazy val worthWhenInheritedBackLink = Some(controllers.routes.GainController.howBecameOwner.url)
   lazy val worthWhenInheritedPostAction = controllers.routes.GainController.submitWorthWhenInherited
 
-  val worthWhenInherited: Action[AnyContent] = ValidateSession.async {implicit request =>
+  def worthWhenInherited: Action[AnyContent] = ValidateSession.async {implicit request =>
     sessionCacheService.fetchAndGetFormData[WorthWhenInheritedModel](keystoreKeys.worthWhenInherited).map {
       case Some(data) => Ok(worthWhenInheritedView(worthWhenInheritedForm.fill(data), worthWhenInheritedBackLink, worthWhenInheritedPostAction))
       case _ => Ok(worthWhenInheritedView(worthWhenInheritedForm, worthWhenInheritedBackLink, worthWhenInheritedPostAction))
     }
   }
 
-  val submitWorthWhenInherited: Action[AnyContent] = ValidateSession.async { implicit request =>
+  def submitWorthWhenInherited: Action[AnyContent] = ValidateSession.async { implicit request =>
     worthWhenInheritedForm.bindFromRequest().fold(
       errors => Future.successful(BadRequest(worthWhenInheritedView(errors, worthWhenInheritedBackLink, worthWhenInheritedPostAction))),
       success => {
@@ -480,14 +480,14 @@ class GainController @Inject()(
   lazy val worthWhenGiftedBackLink = Some(controllers.routes.GainController.howBecameOwner.url)
   lazy val worthWhenGiftedPostAction = controllers.routes.GainController.submitWorthWhenGifted
 
-  val worthWhenGifted: Action[AnyContent] = ValidateSession.async {implicit request =>
+  def worthWhenGifted: Action[AnyContent] = ValidateSession.async {implicit request =>
     sessionCacheService.fetchAndGetFormData[WorthWhenGiftedModel](keystoreKeys.worthWhenGifted).map {
       case Some(data) => Ok(worthWhenGiftedView(worthWhenGiftedForm.fill(data), worthWhenGiftedBackLink, worthWhenGiftedPostAction))
       case _ => Ok(worthWhenGiftedView(worthWhenGiftedForm, worthWhenGiftedBackLink, worthWhenGiftedPostAction))
     }
   }
 
-  val submitWorthWhenGifted: Action[AnyContent] = ValidateSession.async { implicit request =>
+  def submitWorthWhenGifted: Action[AnyContent] = ValidateSession.async { implicit request =>
     worthWhenGiftedForm.bindFromRequest().fold(
       errors => Future.successful(BadRequest(worthWhenGiftedView(errors, worthWhenGiftedBackLink, worthWhenGiftedPostAction))),
       success => {
@@ -499,14 +499,14 @@ class GainController @Inject()(
 
   //################# Worth When Bought For Less Actions ########################
 
-  val worthWhenBoughtForLess: Action[AnyContent] = ValidateSession.async {implicit request =>
+  def worthWhenBoughtForLess: Action[AnyContent] = ValidateSession.async {implicit request =>
     sessionCacheService.fetchAndGetFormData[WorthWhenBoughtForLessModel](keystoreKeys.worthWhenBoughtForLess).map {
       case Some(data) => Ok(worthWhenBoughtForLessView(worthWhenBoughtForLessForm.fill(data)))
       case _ => Ok(worthWhenBoughtForLessView(worthWhenBoughtForLessForm))
     }
   }
 
-  val submitWorthWhenBoughtForLess: Action[AnyContent] = ValidateSession.async { implicit request =>
+  def submitWorthWhenBoughtForLess: Action[AnyContent] = ValidateSession.async { implicit request =>
     worthWhenBoughtForLessForm.bindFromRequest().fold(
       errors => Future.successful(BadRequest(worthWhenBoughtForLessView(errors))),
       success => {
@@ -517,14 +517,14 @@ class GainController @Inject()(
   }
 
   //################# Acquisition Value Actions ########################
-  val acquisitionValue: Action[AnyContent] = ValidateSession.async { implicit request =>
+  def acquisitionValue: Action[AnyContent] = ValidateSession.async { implicit request =>
     sessionCacheService.fetchAndGetFormData[AcquisitionValueModel](keystoreKeys.acquisitionValue).map {
       case Some(data) => Ok(acquisitionValueView(acquisitionValueForm.fill(data)))
       case None => Ok(acquisitionValueView(acquisitionValueForm))
     }
   }
 
-  val submitAcquisitionValue: Action[AnyContent] = ValidateSession.async { implicit request =>
+  def submitAcquisitionValue: Action[AnyContent] = ValidateSession.async { implicit request =>
     acquisitionValueForm.bindFromRequest().fold(
       errors => Future.successful(BadRequest(acquisitionValueView(errors))),
       success => {
@@ -568,14 +568,14 @@ class GainController @Inject()(
     }
   }
 
-  val acquisitionCosts: Action[AnyContent] = ValidateSession.async { implicit request =>
+  def acquisitionCosts: Action[AnyContent] = ValidateSession.async { implicit request =>
     (for {
       backLink <- acquisitionCostsBackLink()
       form <- createAcquisitionCostsForm()
     } yield Ok(acquisitionCostsView(form, backLink))).recoverToStart()
   }
 
-  val submitAcquisitionCosts: Action[AnyContent] = ValidateSession.async { implicit request =>
+  def submitAcquisitionCosts: Action[AnyContent] = ValidateSession.async { implicit request =>
     acquisitionCostsForm.bindFromRequest().fold(
       errors =>
         (for {
@@ -601,14 +601,14 @@ class GainController @Inject()(
     }
   }
 
-  val improvements: Action[AnyContent] = ValidateSession.async { implicit request =>
+  def improvements: Action[AnyContent] = ValidateSession.async { implicit request =>
     (for{
       ownerBeforeAprilNineteenEightyTwo <- getOwnerBeforeAprilNineteenEightyTwo()
       improvementsForm <- getImprovementsForm(ownerBeforeAprilNineteenEightyTwo)
     } yield Ok(improvementsView(improvementsForm, ownerBeforeAprilNineteenEightyTwo))).recoverToStart()
   }
 
-  val submitImprovements: Action[AnyContent] = ValidateSession.async { implicit request =>
+  def submitImprovements: Action[AnyContent] = ValidateSession.async { implicit request =>
 
     def routeRequest(totalGain: BigDecimal): Future[Result] = {
       if (totalGain > 0) Future.successful(Redirect(routes.DeductionsController.propertyLivedIn))

--- a/app/controllers/IncomeController.scala
+++ b/app/controllers/IncomeController.scala
@@ -73,7 +73,7 @@ class IncomeController @Inject()(
     }
   }
 
-  val currentIncome: Action[AnyContent] = ValidateSession.async { implicit request =>
+  def currentIncome: Action[AnyContent] = ValidateSession.async { implicit request =>
 
     def routeRequest(backUrl: String, taxYear: TaxYearModel, currentTaxYear: String): Future[Result] = {
 
@@ -95,7 +95,7 @@ class IncomeController @Inject()(
     } yield finalResult).recoverToStart()
   }
 
-  val submitCurrentIncome: Action[AnyContent] = ValidateSession.async { implicit request =>
+  def submitCurrentIncome: Action[AnyContent] = ValidateSession.async { implicit request =>
 
     def routeRequest(taxYearModel: TaxYearModel, currentTaxYear: String): Future[Result] = {
 
@@ -130,7 +130,7 @@ class IncomeController @Inject()(
   lazy private val backLinkPersonalAllowance = Some(controllers.routes.IncomeController.currentIncome.toString)
   lazy private val postActionPersonalAllowance = controllers.routes.IncomeController.submitPersonalAllowance
 
-  val personalAllowance: Action[AnyContent] = ValidateSession.async { implicit request =>
+  def personalAllowance: Action[AnyContent] = ValidateSession.async { implicit request =>
 
     def fetchKeystorePersonalAllowance(taxYear: TaxYearModel): Future[Form[PersonalAllowanceModel]] = {
       sessionCacheService.fetchAndGetFormData[PersonalAllowanceModel](keystoreKeys.personalAllowance).map {
@@ -156,7 +156,7 @@ class IncomeController @Inject()(
     } yield route).recoverToStart()
   }
 
-  val submitPersonalAllowance: Action[AnyContent] = ValidateSession.async { implicit request =>
+  def submitPersonalAllowance: Action[AnyContent] = ValidateSession.async { implicit request =>
 
     def getMaxPA(year: Int): Future[Option[BigDecimal]] = {
       calcConnector.getPA(year, isEligibleBlindPersonsAllowance = true, isEligibleMarriageAllowance = true)(hc)

--- a/app/controllers/PropertiesController.scala
+++ b/app/controllers/PropertiesController.scala
@@ -30,7 +30,7 @@ class PropertiesController @Inject()(
                                       introductionView: introduction
                                     ) extends FrontendController(messagesControllerComponents) with I18nSupport {
 
-  val introduction: Action[AnyContent] = Action.async { implicit request =>
+  def introduction: Action[AnyContent] = Action.async { implicit request =>
     Future.successful(Ok(introductionView()))
   }
 }

--- a/app/controllers/ReviewAnswersController.scala
+++ b/app/controllers/ReviewAnswersController.scala
@@ -57,7 +57,7 @@ class ReviewAnswersController @Inject()(
   private def languageRequest(body : Lang => Future[Result])(implicit request: Request[_]): Future[Result] =
     body(messagesControllerComponents.messagesApi.preferred(request).lang)
 
-  val reviewGainAnswers: Action[AnyContent] = ValidateSession.async { implicit request =>
+  def reviewGainAnswers: Action[AnyContent] = ValidateSession.async { implicit request =>
     languageRequest { _ =>
       getGainAnswers.map { answers =>
         Ok(checkYourAnswersView(
@@ -70,7 +70,7 @@ class ReviewAnswersController @Inject()(
     }
   }
 
-  val reviewDeductionsAnswers: Action[AnyContent] = ValidateSession.async {
+  def reviewDeductionsAnswers: Action[AnyContent] = ValidateSession.async {
     def generateBackUrl(chargeableGainAnswers: ChargeableGainAnswers): Future[String] = {
       if (chargeableGainAnswers.broughtForwardModel.getOrElse(LossesBroughtForwardModel(false)).option) {
         Future.successful(routes.DeductionsController.lossesBroughtForwardValue.url)
@@ -96,7 +96,7 @@ class ReviewAnswersController @Inject()(
       }
   }
 
-  val reviewFinalAnswers: Action[AnyContent] = ValidateSession.async {
+  def reviewFinalAnswers: Action[AnyContent] = ValidateSession.async {
     implicit request =>
       languageRequest { _ =>
         val getCurrentTaxYear = Dates.getCurrentTaxYear

--- a/app/controllers/ReviewAnswersController.scala
+++ b/app/controllers/ReviewAnswersController.scala
@@ -58,7 +58,7 @@ class ReviewAnswersController @Inject()(
     body(messagesControllerComponents.messagesApi.preferred(request).lang)
 
   val reviewGainAnswers: Action[AnyContent] = ValidateSession.async { implicit request =>
-    languageRequest { implicit lang =>
+    languageRequest { _ =>
       getGainAnswers.map { answers =>
         Ok(checkYourAnswersView(
           routes.SummaryController.summary,
@@ -80,7 +80,7 @@ class ReviewAnswersController @Inject()(
     }
 
     implicit request =>
-      languageRequest { implicit lang =>
+      languageRequest { _ =>
         (for {
           gainAnswers <- getGainAnswers
           deductionsAnswers <- getDeductionsAnswers
@@ -98,7 +98,7 @@ class ReviewAnswersController @Inject()(
 
   val reviewFinalAnswers: Action[AnyContent] = ValidateSession.async {
     implicit request =>
-      languageRequest { implicit lang =>
+      languageRequest { _ =>
         val getCurrentTaxYear = Dates.getCurrentTaxYear
         val getIncomeAnswers = sessionCacheService.getPropertyIncomeAnswers
 

--- a/app/controllers/SaUserController.scala
+++ b/app/controllers/SaUserController.scala
@@ -45,7 +45,7 @@ class SaUserController @Inject()(
 
   implicit val ec: ExecutionContext = messagesControllerComponents.executionContext
 
-  val saUser: Action[AnyContent] = ValidateSession.async { implicit request =>
+  def saUser: Action[AnyContent] = ValidateSession.async { implicit request =>
     for {
       assessmentRequired <- sessionCacheService.shouldSelfAssessmentBeConsidered()
       whereToNext <- {
@@ -58,7 +58,7 @@ class SaUserController @Inject()(
     } yield whereToNext
   }
 
-  val submitSaUser: Action[AnyContent] = ValidateSession.async { implicit request =>
+  def submitSaUser: Action[AnyContent] = ValidateSession.async { implicit request =>
     submitSaUserImpl(true)
   }
 

--- a/app/controllers/SummaryController.scala
+++ b/app/controllers/SummaryController.scala
@@ -47,7 +47,7 @@ class SummaryController @Inject()(
 
   implicit val ec: ExecutionContext = messagesControllerComponents.executionContext
 
-  val summary = ValidateSession.async { implicit request =>
+  def summary = ValidateSession.async { implicit request =>
 
     def chargeableGain(grossGain: BigDecimal,
                        yourAnswersSummaryModel: YourAnswersSummaryModel,

--- a/app/controllers/WhatNextNonSaController.scala
+++ b/app/controllers/WhatNextNonSaController.scala
@@ -38,7 +38,7 @@ class WhatNextNonSaController @Inject()(
 
   implicit val ec: ExecutionContext = messagesControllerComponents.executionContext
 
-  val whatNextNonSaGain: Action[AnyContent] = ValidateSession.async { implicit request =>
+  def whatNextNonSaGain: Action[AnyContent] = ValidateSession.async { implicit request =>
     for {
       selfAssessmentRequired <- sessionCacheService.shouldSelfAssessmentBeConsidered()
     } yield {
@@ -53,7 +53,7 @@ class WhatNextNonSaController @Inject()(
     }
   }
 
-  val whatNextNonSaLoss: Action[AnyContent] = ValidateSession.async { implicit request =>
+  def whatNextNonSaLoss: Action[AnyContent] = ValidateSession.async { implicit request =>
     for {
       selfAssessmentRequired <- sessionCacheService.shouldSelfAssessmentBeConsidered()
     } yield {

--- a/app/controllers/WhatNextSAController.scala
+++ b/app/controllers/WhatNextSAController.scala
@@ -55,17 +55,17 @@ class WhatNextSAController @Inject()(
     }
   }
 
-  val whatNextSAOverFourTimesAEA: Action[AnyContent] = ValidateSession.async { implicit request =>
+  def whatNextSAOverFourTimesAEA: Action[AnyContent] = ValidateSession.async { implicit request =>
     Future.successful(Ok(whatNextSAFourTimesAEAView(backLink)))
   }
 
-  val whatNextSANoGain: Action[AnyContent] = ValidateSession.async { implicit request =>
+  def whatNextSANoGain: Action[AnyContent] = ValidateSession.async { implicit request =>
     fetchAndParseDateToLocalDate().map {
       date => Ok(whatNextSaNoGainView(backLink, iFormUrl, taxYearOfDateLongHand(date)))
     }.recoverToStart()
   }
 
-  val whatNextSAGain: Action[AnyContent] = ValidateSession.async { implicit request =>
+  def whatNextSAGain: Action[AnyContent] = ValidateSession.async { implicit request =>
     fetchAndParseDateToLocalDate().map {
       date => Ok(whatNextSaGainView(backLink, iFormUrl, taxYearOfDateLongHand(date)))
     }.recoverToStart()

--- a/app/controllers/predicates/ValidActiveSession.scala
+++ b/app/controllers/predicates/ValidActiveSession.scala
@@ -32,7 +32,7 @@ trait ValidActiveSession extends FrontendController {
     def async(action: AsyncRequest): Action[AnyContent] = {
       Action.async { implicit request =>
         if (request.session.get(SessionKeys.sessionId).isEmpty) {
-          Future.successful(Redirect(routes.TimeoutController.timeout))
+          Future.successful(Redirect(routes.TimeoutController.timeout()))
         } else {
           action(request)
         }

--- a/app/controllers/utils/package.scala
+++ b/app/controllers/utils/package.scala
@@ -37,7 +37,7 @@ package object utils {
       future.recover {
         case e: NoSuchElementException =>
           throw ApplicationException(
-            Redirect(controllers.routes.TimeoutController.timeout),
+            Redirect(controllers.routes.TimeoutController.timeout()),
             "cgt-calculator-resident-properties-frontend" + e.getMessage
           )
       }

--- a/app/models/SummaryDataItemModel.scala
+++ b/app/models/SummaryDataItemModel.scala
@@ -16,10 +16,10 @@
 
 package models
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, Format}
 
 case class SummaryDataItemModel (question: String, answer: String, link: Option[String] = None)
 
 object SummaryDataItemModel {
-  implicit val format = Json.format[SummaryDataItemModel]
+  implicit val format: Format[SummaryDataItemModel] = Json.format[SummaryDataItemModel]
 }

--- a/app/models/resident/AcquisitionCostsModel.scala
+++ b/app/models/resident/AcquisitionCostsModel.scala
@@ -16,10 +16,10 @@
 
 package models.resident
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Format, Json}
 
 case class AcquisitionCostsModel (amount: BigDecimal)
 
 object AcquisitionCostsModel {
-  implicit val format = Json.format[AcquisitionCostsModel]
+  implicit val format: Format[AcquisitionCostsModel] = Json.format[AcquisitionCostsModel]
 }

--- a/app/models/resident/AcquisitionValueModel.scala
+++ b/app/models/resident/AcquisitionValueModel.scala
@@ -16,10 +16,10 @@
 
 package models.resident
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Format, Json}
 
 case class AcquisitionValueModel (amount: BigDecimal)
 
 object AcquisitionValueModel {
-  implicit val format = Json.format[AcquisitionValueModel]
+  implicit val format : Format[AcquisitionValueModel] = Json.format[AcquisitionValueModel]
 }

--- a/app/models/resident/ChargeableGainResultModel.scala
+++ b/app/models/resident/ChargeableGainResultModel.scala
@@ -16,7 +16,7 @@
 
 package models.resident
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Format, Json}
 
 case class ChargeableGainResultModel (
                                        gain: BigDecimal,
@@ -33,5 +33,5 @@ case class ChargeableGainResultModel (
                                      )
 
 object ChargeableGainResultModel {
-  implicit val format = Json.format[ChargeableGainResultModel]
+  implicit val format : Format[ChargeableGainResultModel] = Json.format[ChargeableGainResultModel]
 }

--- a/app/models/resident/DisposalCostsModel.scala
+++ b/app/models/resident/DisposalCostsModel.scala
@@ -16,10 +16,10 @@
 
 package models.resident
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Format, Json}
 
 case class DisposalCostsModel(amount: BigDecimal)
 
 object DisposalCostsModel {
-  implicit val format = Json.format[DisposalCostsModel]
+  implicit val format : Format[DisposalCostsModel] = Json.format[DisposalCostsModel]
 }

--- a/app/models/resident/DisposalDateModel.scala
+++ b/app/models/resident/DisposalDateModel.scala
@@ -16,10 +16,10 @@
 
 package models.resident
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Format, Json}
 
 case class DisposalDateModel (day: Int, month: Int, year: Int)
 
 object DisposalDateModel {
-  implicit val formats = Json.format[DisposalDateModel]
+  implicit val formats : Format[DisposalDateModel] = Json.format[DisposalDateModel]
 }

--- a/app/models/resident/DisposalValueModel.scala
+++ b/app/models/resident/DisposalValueModel.scala
@@ -16,10 +16,10 @@
 
 package models.resident
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Format, Json}
 
 case class DisposalValueModel(amount: BigDecimal)
 
 object DisposalValueModel {
-  implicit val format = Json.format[DisposalValueModel]
+  implicit val format : Format[DisposalValueModel] = Json.format[DisposalValueModel]
 }

--- a/app/models/resident/LossesBroughtForwardModel.scala
+++ b/app/models/resident/LossesBroughtForwardModel.scala
@@ -16,10 +16,10 @@
 
 package models.resident
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Format, Json}
 
 case class LossesBroughtForwardModel(option : Boolean)
 
 object LossesBroughtForwardModel {
-  implicit val format = Json.format[LossesBroughtForwardModel]
+  implicit val format : Format[LossesBroughtForwardModel] = Json.format[LossesBroughtForwardModel]
 }

--- a/app/models/resident/LossesBroughtForwardValueModel.scala
+++ b/app/models/resident/LossesBroughtForwardValueModel.scala
@@ -16,10 +16,10 @@
 
 package models.resident
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Format, Json}
 
 case class LossesBroughtForwardValueModel (amount: BigDecimal)
 
 object LossesBroughtForwardValueModel {
-  implicit val format = Json.format[LossesBroughtForwardValueModel]
+  implicit val format : Format[LossesBroughtForwardValueModel] = Json.format[LossesBroughtForwardValueModel]
 }

--- a/app/models/resident/PrivateResidenceReliefModel.scala
+++ b/app/models/resident/PrivateResidenceReliefModel.scala
@@ -16,10 +16,10 @@
 
 package models.resident
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Format, Json}
 
 case class PrivateResidenceReliefModel (isClaiming: Boolean)
 
 object PrivateResidenceReliefModel {
-  implicit val format = Json.format[PrivateResidenceReliefModel]
+  implicit val format : Format[PrivateResidenceReliefModel] = Json.format[PrivateResidenceReliefModel]
 }

--- a/app/models/resident/SellForLessModel.scala
+++ b/app/models/resident/SellForLessModel.scala
@@ -16,10 +16,10 @@
 
 package models.resident
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Format, Json}
 
 case class SellForLessModel (sellForLess: Boolean)
 
 object SellForLessModel {
-  implicit val format = Json.format[SellForLessModel]
+  implicit val format : Format[SellForLessModel] = Json.format[SellForLessModel]
 }

--- a/app/models/resident/TaxYearModel.scala
+++ b/app/models/resident/TaxYearModel.scala
@@ -16,7 +16,7 @@
 
 package models.resident
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Format, Json}
 
 case class TaxYearModel (taxYearSupplied: String, isValidYear: Boolean, calculationTaxYear: String) {
   val startYear: String = TaxYearModel.convertToSummaryFormat(taxYearSupplied)(0)
@@ -24,7 +24,7 @@ case class TaxYearModel (taxYearSupplied: String, isValidYear: Boolean, calculat
 }
 
 object TaxYearModel {
-  implicit val formats = Json.format[TaxYearModel]
+  implicit val formats : Format[TaxYearModel] = Json.format[TaxYearModel]
 
   def convertToSummaryFormat(taxYear: String): Seq[String] = {
     val startYear = taxYear.take(4)

--- a/app/models/resident/TotalGainAndTaxOwedModel.scala
+++ b/app/models/resident/TotalGainAndTaxOwedModel.scala
@@ -16,7 +16,7 @@
 
 package models.resident
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Format, Json}
 
 case class TotalGainAndTaxOwedModel(gain: BigDecimal,
                                     chargeableGain: BigDecimal,
@@ -36,5 +36,5 @@ case class TotalGainAndTaxOwedModel(gain: BigDecimal,
                                    )
 
 object TotalGainAndTaxOwedModel {
-  implicit val formats = Json.format[TotalGainAndTaxOwedModel]
+  implicit val formats : Format[TotalGainAndTaxOwedModel] = Json.format[TotalGainAndTaxOwedModel]
 }

--- a/app/models/resident/WorthWhenInheritedModel.scala
+++ b/app/models/resident/WorthWhenInheritedModel.scala
@@ -16,10 +16,10 @@
 
 package models.resident
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Format, Json}
 
 case class WorthWhenInheritedModel (amount: BigDecimal)
 
 object WorthWhenInheritedModel {
-  implicit val format = Json.format[WorthWhenInheritedModel]
+  implicit val format : Format[WorthWhenInheritedModel] = Json.format[WorthWhenInheritedModel]
 }

--- a/app/models/resident/WorthWhenSoldForLessModel.scala
+++ b/app/models/resident/WorthWhenSoldForLessModel.scala
@@ -16,10 +16,10 @@
 
 package models.resident
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Format, Json}
 
 case class WorthWhenSoldForLessModel(amount: BigDecimal)
 
 object WorthWhenSoldForLessModel {
-  implicit val format = Json.format[WorthWhenSoldForLessModel]
+  implicit val format : Format[WorthWhenSoldForLessModel] = Json.format[WorthWhenSoldForLessModel]
 }

--- a/app/models/resident/income/CurrentIncomeModel.scala
+++ b/app/models/resident/income/CurrentIncomeModel.scala
@@ -16,10 +16,10 @@
 
 package models.resident.income
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Format, Json}
 
 case class CurrentIncomeModel(amount: BigDecimal)
 
 object CurrentIncomeModel {
-  implicit val format = Json.format[CurrentIncomeModel]
+  implicit val format : Format[CurrentIncomeModel] = Json.format[CurrentIncomeModel]
 }

--- a/app/models/resident/income/PersonalAllowanceModel.scala
+++ b/app/models/resident/income/PersonalAllowanceModel.scala
@@ -16,10 +16,10 @@
 
 package models.resident.income
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Format, Json}
 
 case class PersonalAllowanceModel(amount: BigDecimal)
 
 object PersonalAllowanceModel {
-  implicit val format = Json.format[PersonalAllowanceModel]
+  implicit val format : Format[PersonalAllowanceModel] = Json.format[PersonalAllowanceModel]
 }

--- a/app/models/resident/income/PreviousTaxableGainsModel.scala
+++ b/app/models/resident/income/PreviousTaxableGainsModel.scala
@@ -16,10 +16,10 @@
 
 package models.resident.income
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Format, Json}
 
 case class PreviousTaxableGainsModel(amount: BigDecimal)
 
 object PreviousTaxableGainsModel {
-  implicit val format = Json.format[PreviousTaxableGainsModel]
+  implicit val format : Format[PreviousTaxableGainsModel] = Json.format[PreviousTaxableGainsModel]
 }

--- a/app/models/resident/properties/BoughtForLessThanWorthModel.scala
+++ b/app/models/resident/properties/BoughtForLessThanWorthModel.scala
@@ -16,10 +16,10 @@
 
 package models.resident.properties
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, Format}
 
 case class BoughtForLessThanWorthModel(boughtForLessThanWorth: Boolean)
 
 object BoughtForLessThanWorthModel {
-  implicit val format = Json.format[BoughtForLessThanWorthModel]
+  implicit val format : Format[BoughtForLessThanWorthModel] = Json.format[BoughtForLessThanWorthModel]
 }

--- a/app/models/resident/properties/HowBecameOwnerModel.scala
+++ b/app/models/resident/properties/HowBecameOwnerModel.scala
@@ -16,10 +16,10 @@
 
 package models.resident.properties
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Format, Json}
 
 case class HowBecameOwnerModel(gainedBy: String)
 
 object HowBecameOwnerModel {
-  implicit val format = Json.format[HowBecameOwnerModel]
+  implicit val format : Format[HowBecameOwnerModel] = Json.format[HowBecameOwnerModel]
 }

--- a/app/models/resident/properties/ImprovementsModel.scala
+++ b/app/models/resident/properties/ImprovementsModel.scala
@@ -16,10 +16,10 @@
 
 package models.resident.properties
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Format, Json}
 
 case class ImprovementsModel(amount: BigDecimal)
 
 object ImprovementsModel {
-  implicit val format = Json.format[ImprovementsModel]
+  implicit val format : Format[ImprovementsModel] = Json.format[ImprovementsModel]
 }

--- a/app/models/resident/properties/LettingsReliefModel.scala
+++ b/app/models/resident/properties/LettingsReliefModel.scala
@@ -16,10 +16,10 @@
 
 package models.resident.properties
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Format, Json}
 
 case class LettingsReliefModel (isClaiming: Boolean)
 
 object LettingsReliefModel {
-  implicit val format = Json.format[LettingsReliefModel]
+  implicit val format : Format[LettingsReliefModel] = Json.format[LettingsReliefModel]
 }

--- a/app/models/resident/properties/LettingsReliefValueModel.scala
+++ b/app/models/resident/properties/LettingsReliefValueModel.scala
@@ -16,10 +16,10 @@
 
 package models.resident.properties
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Format, Json}
 
 case class LettingsReliefValueModel(amount: BigDecimal)
 
 object LettingsReliefValueModel {
-  implicit val format = Json.format[LettingsReliefValueModel]
+  implicit val format : Format[LettingsReliefValueModel] = Json.format[LettingsReliefValueModel]
 }

--- a/app/models/resident/properties/PrivateResidenceReliefValueModel.scala
+++ b/app/models/resident/properties/PrivateResidenceReliefValueModel.scala
@@ -16,10 +16,10 @@
 
 package models.resident.properties
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Format, Json}
 
 case class PrivateResidenceReliefValueModel(amount: BigDecimal)
 
 object PrivateResidenceReliefValueModel {
-  implicit val format = Json.format[PrivateResidenceReliefValueModel]
+  implicit val format : Format[PrivateResidenceReliefValueModel] = Json.format[PrivateResidenceReliefValueModel]
 }

--- a/app/models/resident/properties/PropertyLivedInModel.scala
+++ b/app/models/resident/properties/PropertyLivedInModel.scala
@@ -16,10 +16,10 @@
 
 package models.resident.properties
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Format, Json}
 
 case class PropertyLivedInModel (livedInProperty: Boolean)
 
 object PropertyLivedInModel {
-  implicit val format = Json.format[PropertyLivedInModel]
+  implicit val format : Format[PropertyLivedInModel] = Json.format[PropertyLivedInModel]
 }

--- a/app/models/resident/properties/SellOrGiveAwayModel.scala
+++ b/app/models/resident/properties/SellOrGiveAwayModel.scala
@@ -16,10 +16,10 @@
 
 package models.resident.properties
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Format, Json}
 
 case class SellOrGiveAwayModel (givenAway: Boolean)
 
 object SellOrGiveAwayModel {
-  implicit val format = Json.format[SellOrGiveAwayModel]
+  implicit val format : Format[SellOrGiveAwayModel] = Json.format[SellOrGiveAwayModel]
 }

--- a/app/models/resident/properties/ValueBeforeLegislationStartModel.scala
+++ b/app/models/resident/properties/ValueBeforeLegislationStartModel.scala
@@ -16,10 +16,10 @@
 
 package models.resident.properties
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Format, Json}
 
 case class ValueBeforeLegislationStartModel(amount: BigDecimal)
 
 object ValueBeforeLegislationStartModel {
-  implicit val format = Json.format[ValueBeforeLegislationStartModel]
+  implicit val format : Format[ValueBeforeLegislationStartModel] = Json.format[ValueBeforeLegislationStartModel]
 }

--- a/app/models/resident/properties/WorthWhenBoughtForLessModel.scala
+++ b/app/models/resident/properties/WorthWhenBoughtForLessModel.scala
@@ -16,10 +16,10 @@
 
 package models.resident.properties
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Format, Json}
 
 case class WorthWhenBoughtForLessModel(amount: BigDecimal)
 
 object WorthWhenBoughtForLessModel {
-  implicit val format = Json.format[WorthWhenBoughtForLessModel]
+  implicit val format : Format[WorthWhenBoughtForLessModel] = Json.format[WorthWhenBoughtForLessModel]
 }

--- a/app/models/resident/properties/WorthWhenGaveAwayModel.scala
+++ b/app/models/resident/properties/WorthWhenGaveAwayModel.scala
@@ -16,10 +16,10 @@
 
 package models.resident.properties
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Format, Json}
 
 case class WorthWhenGaveAwayModel(amount: BigDecimal)
 
 object WorthWhenGaveAwayModel {
-  implicit val format = Json.format[WorthWhenGaveAwayModel]
+  implicit val format : Format[WorthWhenGaveAwayModel] = Json.format[WorthWhenGaveAwayModel]
 }

--- a/app/models/resident/properties/YourAnswersSummaryModel.scala
+++ b/app/models/resident/properties/YourAnswersSummaryModel.scala
@@ -52,10 +52,10 @@ case class YourAnswersSummaryModel(
 
 object YourAnswersSummaryModel {
 
-  implicit val localDateFormat = new Format[LocalDate] {
+  implicit val localDateFormat: Format[LocalDate] = new Format[LocalDate] {
     override def reads(json: JsValue): JsResult[LocalDate] = json.validate[String].map(LocalDate.parse(_,formatter))
     override def writes(o: LocalDate): JsValue = Json.toJson(o.toString)
   }
 
-  implicit val format = Json.format[YourAnswersSummaryModel]
+  implicit val format: Format[YourAnswersSummaryModel] = Json.format[YourAnswersSummaryModel]
 }

--- a/app/models/resident/properties/gain/OwnerBeforeLegislationStartModel.scala
+++ b/app/models/resident/properties/gain/OwnerBeforeLegislationStartModel.scala
@@ -16,10 +16,10 @@
 
 package models.resident.properties.gain
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Format, Json}
 
 case class OwnerBeforeLegislationStartModel(ownedBeforeLegislationStart: Boolean)
 
 object OwnerBeforeLegislationStartModel {
-  implicit val format = Json.format[OwnerBeforeLegislationStartModel]
+  implicit val format : Format[OwnerBeforeLegislationStartModel] = Json.format[OwnerBeforeLegislationStartModel]
 }

--- a/app/models/resident/properties/gain/WhoDidYouGiveItToModel.scala
+++ b/app/models/resident/properties/gain/WhoDidYouGiveItToModel.scala
@@ -16,10 +16,10 @@
 
 package models.resident.properties.gain
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Format, Json}
 
 case class WhoDidYouGiveItToModel(option: String)
 
 object WhoDidYouGiveItToModel {
-  implicit val format = Json.format[WhoDidYouGiveItToModel]
+  implicit val format : Format[WhoDidYouGiveItToModel] = Json.format[WhoDidYouGiveItToModel]
 }

--- a/app/models/resident/properties/gain/WorthWhenGiftedModel.scala
+++ b/app/models/resident/properties/gain/WorthWhenGiftedModel.scala
@@ -16,10 +16,10 @@
 
 package models.resident.properties.gain
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Format, Json}
 
 case class WorthWhenGiftedModel (amount: BigDecimal)
 
 object WorthWhenGiftedModel {
-  implicit val format = Json.format[WorthWhenGiftedModel]
+  implicit val format : Format[WorthWhenGiftedModel] = Json.format[WorthWhenGiftedModel]
 }

--- a/app/services/SessionCacheService.scala
+++ b/app/services/SessionCacheService.scala
@@ -127,7 +127,7 @@ class SessionCacheService @Inject()(sessionRepository: SessionRepository,
   }.recover {
     case e: NoSuchElementException =>
       throw ApplicationException(
-        Redirect(controllers.routes.TimeoutController.timeout),
+        Redirect(controllers.routes.TimeoutController.timeout()),
         e.getMessage
       )
   }
@@ -163,7 +163,7 @@ class SessionCacheService @Inject()(sessionRepository: SessionRepository,
   }.recover {
     case e: NoSuchElementException =>
       throw ApplicationException(
-        Redirect(controllers.routes.TimeoutController.timeout),
+        Redirect(controllers.routes.TimeoutController.timeout()),
         e.getMessage
       )
   }
@@ -181,7 +181,7 @@ class SessionCacheService @Inject()(sessionRepository: SessionRepository,
   }.recover {
     case e: NoSuchElementException =>
       throw ApplicationException(
-        Redirect(controllers.routes.TimeoutController.timeout),
+        Redirect(controllers.routes.TimeoutController.timeout()),
         e.getMessage
       )
   }
@@ -194,7 +194,7 @@ class SessionCacheService @Inject()(sessionRepository: SessionRepository,
   }.recover {
     case e: NoSuchElementException =>
       throw ApplicationException(
-        Redirect(controllers.routes.TimeoutController.timeout),
+        Redirect(controllers.routes.TimeoutController.timeout()),
         e.getMessage
       )
   }

--- a/app/views/Layout.scala.html
+++ b/app/views/Layout.scala.html
@@ -15,6 +15,9 @@
  *@
 
 @import config.ApplicationConfig
+@import uk.gov.hmrc.govukfrontend.views.html.components._
+@import uk.gov.hmrc.hmrcfrontend.views.html.components._
+@import uk.gov.hmrc.hmrcfrontend.views.html.helpers._
 @import uk.gov.hmrc.hmrcfrontend.views.viewmodels.hmrcstandardpage._
 
 @this(

--- a/app/views/Layout.scala.html
+++ b/app/views/Layout.scala.html
@@ -42,14 +42,10 @@
     messages: Messages
 )
 
-@accountMenu = {
-    @hmrcLanguageSelectHelper()
-}
-
 @head = {
     @if(timeoutEnabled) {
         @hmrcTimeoutDialogHelper(
-            signOutUrl = controllers.routes.TimeoutController.timeout.url
+            signOutUrl = controllers.routes.TimeoutController.timeout().url
         )
     }
     <link rel="stylesheet" type="text/css" href ='@routes.Assets.versioned("stylesheets/cgt-calculator-resident-properties.css")'>

--- a/app/views/calculation/resident/lossesBroughtForward.scala.html
+++ b/app/views/calculation/resident/lossesBroughtForward.scala.html
@@ -16,7 +16,7 @@
 
 @import models.resident._
 @import play.api.mvc.Call
-@import uk.gov.hmrc.govukfrontend.views.html.components.FormWithCSRF
+@import uk.gov.hmrc.govukfrontend.views.html.components.{FormWithCSRF, _}
 
 @this(
     errorSummary: playHelpers.errorSummary,

--- a/app/views/calculation/resident/properties/checkYourAnswers/checkYourAnswers.scala.html
+++ b/app/views/calculation/resident/properties/checkYourAnswers/checkYourAnswers.scala.html
@@ -24,7 +24,7 @@
         link: playHelpers.link
 )
 
-@(postAction: Call, backUrl: String, gainAnswers: YourAnswersSummaryModel, deductionsAnswers: Option[ChargeableGainAnswers], taxYear: Option[TaxYearModel], incomeAnswers: Option[IncomeAnswersModel] = None, isCurrentTaxYear: Boolean = false)(implicit request: Request[_], messages: Messages, lang: Lang)
+@(postAction: Call, backUrl: String, gainAnswers: YourAnswersSummaryModel, deductionsAnswers: Option[ChargeableGainAnswers], taxYear: Option[TaxYearModel], incomeAnswers: Option[IncomeAnswersModel] = None, isCurrentTaxYear: Boolean = false)(implicit request: Request[_], messages: Messages)
 
 @layout(
     pageTitle = Messages("calc.checkYourAnswers.title")

--- a/app/views/calculation/resident/properties/deductions/lettingsRelief.scala.html
+++ b/app/views/calculation/resident/properties/deductions/lettingsRelief.scala.html
@@ -15,7 +15,7 @@
  *@
 
 @import models.resident.properties.LettingsReliefModel
-@import uk.gov.hmrc.govukfrontend.views.html.components.FormWithCSRF
+@import uk.gov.hmrc.govukfrontend.views.html.components.{FormWithCSRF, _}
 
 @this(
     form: FormWithCSRF,

--- a/app/views/calculation/resident/properties/deductions/lettingsReliefValue.scala.html
+++ b/app/views/calculation/resident/properties/deductions/lettingsReliefValue.scala.html
@@ -28,9 +28,6 @@
 
 @(lettingsReliefValueForm : Form[LettingsReliefValueModel], totalGain: BigDecimal)(implicit request: Request[_], messages: Messages)
 
-@title = @{
-    if (lettingsReliefValueForm.errors.nonEmpty) Messages("site.title.error",  Messages("calc.resident.lettingsReliefValue.title")) else Messages("calc.resident.lettingsReliefValue.title")
-}
 @layout(
     pageTitle = Messages("calc.resident.lettingsReliefValue.title")
 ){

--- a/app/views/calculation/resident/properties/deductions/privateResidenceRelief.scala.html
+++ b/app/views/calculation/resident/properties/deductions/privateResidenceRelief.scala.html
@@ -15,7 +15,7 @@
  *@
 
 @import models.resident.PrivateResidenceReliefModel
-@import uk.gov.hmrc.govukfrontend.views.html.components.FormWithCSRF
+@import uk.gov.hmrc.govukfrontend.views.html.components.{FormWithCSRF, _}
 
 @this(
     form: FormWithCSRF,

--- a/app/views/calculation/resident/properties/deductions/propertyLivedIn.scala.html
+++ b/app/views/calculation/resident/properties/deductions/propertyLivedIn.scala.html
@@ -15,7 +15,7 @@
  *@
 
 @import models.resident.properties.PropertyLivedInModel
-@import uk.gov.hmrc.govukfrontend.views.html.components.FormWithCSRF
+@import uk.gov.hmrc.govukfrontend.views.html.components.{FormWithCSRF, _}
 
 @this(
     layout: Layout,

--- a/app/views/calculation/resident/properties/gain/buyForLess.scala.html
+++ b/app/views/calculation/resident/properties/gain/buyForLess.scala.html
@@ -15,7 +15,7 @@
  *@
 
 @import models.resident.properties.BoughtForLessThanWorthModel
-@import uk.gov.hmrc.govukfrontend.views.html.components.FormWithCSRF
+@import uk.gov.hmrc.govukfrontend.views.html.components.{FormWithCSRF, _}
 
 @this(
     form: FormWithCSRF,

--- a/app/views/calculation/resident/properties/gain/disposalCosts.scala.html
+++ b/app/views/calculation/resident/properties/gain/disposalCosts.scala.html
@@ -15,7 +15,7 @@
  *@
 
 @import models.resident.DisposalCostsModel
-@import uk.gov.hmrc.govukfrontend.views.html.components.FormWithCSRF
+@import uk.gov.hmrc.govukfrontend.views.html.components.{FormWithCSRF, _}
 
 @this(
     form: FormWithCSRF,

--- a/app/views/calculation/resident/properties/gain/howBecameOwner.scala.html
+++ b/app/views/calculation/resident/properties/gain/howBecameOwner.scala.html
@@ -15,7 +15,7 @@
  *@
 
 @import models.resident.properties.HowBecameOwnerModel
-@import uk.gov.hmrc.govukfrontend.views.html.components.FormWithCSRF
+@import uk.gov.hmrc.govukfrontend.views.html.components.{FormWithCSRF, _}
 
 @this(
     form: FormWithCSRF,

--- a/app/views/calculation/resident/properties/gain/ownerBeforeLegislationStart.scala.html
+++ b/app/views/calculation/resident/properties/gain/ownerBeforeLegislationStart.scala.html
@@ -15,7 +15,7 @@
  *@
 
 @import models.resident.properties.gain.OwnerBeforeLegislationStartModel
-@import uk.gov.hmrc.govukfrontend.views.html.components.FormWithCSRF
+@import uk.gov.hmrc.govukfrontend.views.html.components.{FormWithCSRF, _}
 
 @this(
     layout: Layout,

--- a/app/views/calculation/resident/properties/gain/sellForLess.scala.html
+++ b/app/views/calculation/resident/properties/gain/sellForLess.scala.html
@@ -15,7 +15,7 @@
  *@
 
 @import models.resident.SellForLessModel
-@import uk.gov.hmrc.govukfrontend.views.html.components.FormWithCSRF
+@import uk.gov.hmrc.govukfrontend.views.html.components.{FormWithCSRF, _}
 
 @this(
     layout: Layout,

--- a/app/views/calculation/resident/properties/gain/sellOrGiveAway.scala.html
+++ b/app/views/calculation/resident/properties/gain/sellOrGiveAway.scala.html
@@ -15,7 +15,7 @@
  *@
 
 @import models.resident.properties.SellOrGiveAwayModel
-@import uk.gov.hmrc.govukfrontend.views.html.components.FormWithCSRF
+@import uk.gov.hmrc.govukfrontend.views.html.components.{FormWithCSRF, _}
 
 @this(
     layout: Layout,

--- a/app/views/calculation/resident/properties/gain/whoDidYouGiveItTo.scala.html
+++ b/app/views/calculation/resident/properties/gain/whoDidYouGiveItTo.scala.html
@@ -15,7 +15,7 @@
  *@
 
 @import models.resident.properties.gain.WhoDidYouGiveItToModel
-@import uk.gov.hmrc.govukfrontend.views.html.components.FormWithCSRF
+@import uk.gov.hmrc.govukfrontend.views.html.components.{FormWithCSRF, _}
 
 @this(
     form: FormWithCSRF,

--- a/app/views/calculation/resident/properties/gain/worthWhenGaveAway.scala.html
+++ b/app/views/calculation/resident/properties/gain/worthWhenGaveAway.scala.html
@@ -15,7 +15,7 @@
  *@
 
 @import models.resident.properties.WorthWhenGaveAwayModel
-@import uk.gov.hmrc.govukfrontend.views.html.components.FormWithCSRF
+@import uk.gov.hmrc.govukfrontend.views.html.components.{FormWithCSRF, _}
 
 @this(
     form: FormWithCSRF,

--- a/app/views/calculation/resident/properties/gain/worthWhenGifted.scala.html
+++ b/app/views/calculation/resident/properties/gain/worthWhenGifted.scala.html
@@ -15,7 +15,7 @@
  *@
 
 @import models.resident.properties.gain.WorthWhenGiftedModel
-@import uk.gov.hmrc.govukfrontend.views.html.components.FormWithCSRF
+@import uk.gov.hmrc.govukfrontend.views.html.components.{FormWithCSRF, _}
 
 @this(
     govukInsetText : GovukInsetText,

--- a/app/views/calculation/resident/properties/introduction.scala.html
+++ b/app/views/calculation/resident/properties/introduction.scala.html
@@ -14,6 +14,8 @@
  * limitations under the License.
  *@
 
+@import uk.gov.hmrc.govukfrontend.views.html.components._
+
 @this(
     layout: Layout,
     govukButton : GovukButton,

--- a/app/views/calculation/resident/properties/whatNext/saUser.scala.html
+++ b/app/views/calculation/resident/properties/whatNext/saUser.scala.html
@@ -15,7 +15,7 @@
  *@
 
 @import models.resident.SaUserModel
-@import uk.gov.hmrc.govukfrontend.views.html.components.FormWithCSRF
+@import uk.gov.hmrc.govukfrontend.views.html.components.{FormWithCSRF, _}
 
 @this(
     form: FormWithCSRF,

--- a/app/views/calculation/resident/properties/whatNext/whatNextNonSaGain.scala.html
+++ b/app/views/calculation/resident/properties/whatNext/whatNextNonSaGain.scala.html
@@ -14,6 +14,8 @@
  * limitations under the License.
  *@
 
+@import uk.gov.hmrc.govukfrontend.views.html.components._
+
 @this(
     layout: Layout,
     govukButton: GovukButton

--- a/app/views/calculation/resident/properties/whatNext/whatNextNonSaLoss.scala.html
+++ b/app/views/calculation/resident/properties/whatNext/whatNextNonSaLoss.scala.html
@@ -14,6 +14,8 @@
  * limitations under the License.
  *@
 
+@import uk.gov.hmrc.govukfrontend.views.html.components._
+
 @this(
     govukButton: GovukButton,
     layout: Layout

--- a/app/views/calculation/resident/properties/whatNext/whatNextSAFourTimesAEA.scala.html
+++ b/app/views/calculation/resident/properties/whatNext/whatNextSAFourTimesAEA.scala.html
@@ -21,13 +21,7 @@
 
 @(backLink: String)(implicit request : Request[_], messages: Messages)
 
-    @title = @{
-        Messages("calc.whatToDoNext.title")
-    }
-
-    @layout(
-        pageTitle = Messages("calc.whatToDoNext.title")
-    ) {
+@layout(pageTitle = Messages("calc.whatToDoNext.title")) {
 
     <h1 class="govuk-heading-xl">@Messages("calc.whatToDoNext.title")</h1>
 

--- a/app/views/calculation/resident/properties/whatNext/whatNextSaGain.scala.html
+++ b/app/views/calculation/resident/properties/whatNext/whatNextSaGain.scala.html
@@ -14,6 +14,8 @@
  * limitations under the License.
  *@
 
+@import uk.gov.hmrc.govukfrontend.views.html.components._
+
 @this(
     layout: Layout,
     govukButton: GovukButton

--- a/app/views/calculation/resident/properties/whatNext/whatNextSaNoGain.scala.html
+++ b/app/views/calculation/resident/properties/whatNext/whatNextSaNoGain.scala.html
@@ -14,6 +14,8 @@
  * limitations under the License.
  *@
 
+@import uk.gov.hmrc.govukfrontend.views.html.components._
+
 @this(
     layout: Layout,
     govukButton: GovukButton

--- a/app/views/playHelpers/deductionsSummaryPartial.scala.html
+++ b/app/views/playHelpers/deductionsSummaryPartial.scala.html
@@ -28,7 +28,7 @@
     deductionAnswers: ChargeableGainAnswers,
     result: ChargeableGainResultModel,
     taxYear: TaxYearModel,
-    totalCosts: BigDecimal)(implicit request: Request[_], messages: Messages)
+    totalCosts: BigDecimal)(implicit messages: Messages)
 
 <div id="tax-owed-banner" class="govuk-panel govuk-panel--confirmation">
     <h1 class="govuk-panel__title">@Messages("calc.summary.cgtToPay", TaxYearModel.convertToSummaryFormat(taxYear.taxYearSupplied):_*)</h1>

--- a/app/views/playHelpers/deductionsSummaryPartial.scala.html
+++ b/app/views/playHelpers/deductionsSummaryPartial.scala.html
@@ -17,7 +17,7 @@
 @import common.resident.MoneyPounds
 @import models.resident._
 @import models.resident.properties._
-
+@import uk.gov.hmrc.govukfrontend.views.html.components._
 
 @this(
     summaryNumericRow: playHelpers.resident.summaryNumericRow,

--- a/app/views/playHelpers/errorSummary.scala.html
+++ b/app/views/playHelpers/errorSummary.scala.html
@@ -14,6 +14,8 @@
  * limitations under the License.
  *@
 
+@import uk.gov.hmrc.govukfrontend.views.html.components._
+
 @this(
         govukErrorSummary: GovukErrorSummary
 )

--- a/app/views/playHelpers/finalSummaryPartial.scala.html
+++ b/app/views/playHelpers/finalSummaryPartial.scala.html
@@ -32,7 +32,7 @@
     prrUsed: Option[Boolean] = None,
     lettingsReliefUsed: Option[Boolean] = None,
     totalCosts: BigDecimal,
-    totalDeductions: BigDecimal)(implicit request: Request[_], messages: Messages)
+    totalDeductions: BigDecimal)(implicit messages: Messages)
 
 <div id="tax-owed-banner" class="govuk-panel govuk-panel--confirmation">
     <h1 class="govuk-panel__title">@Messages("calc.summary.cgtToPay", TaxYearModel.convertToSummaryFormat(taxYear.taxYearSupplied):_*)</h1>

--- a/app/views/playHelpers/finalSummaryPartial.scala.html
+++ b/app/views/playHelpers/finalSummaryPartial.scala.html
@@ -17,6 +17,7 @@
 @import common.resident.MoneyPounds
 @import models.resident._
 @import models.resident.properties._
+@import uk.gov.hmrc.govukfrontend.views.html.components._
 @import views.html.playHelpers.resident._
 
 @this(

--- a/app/views/playHelpers/formInputMoney.scala.html
+++ b/app/views/playHelpers/formInputMoney.scala.html
@@ -15,7 +15,7 @@
  *@
 
 @import uk.gov.hmrc.govukfrontend.views.html.components._
-
+@import uk.gov.hmrc.govukfrontend.views.html.components.implicits._
 
 @this(govukInput : GovukInput)
 

--- a/app/views/playHelpers/gainSummaryPartial.scala.html
+++ b/app/views/playHelpers/gainSummaryPartial.scala.html
@@ -17,6 +17,7 @@
 @import common.resident.MoneyPounds
 @import models.resident._
 @import models.resident.properties._
+@import uk.gov.hmrc.govukfrontend.views.html.components._
 @import views.html.playHelpers.resident._
 
 @this(

--- a/app/views/playHelpers/gainSummaryPartial.scala.html
+++ b/app/views/playHelpers/gainSummaryPartial.scala.html
@@ -28,7 +28,7 @@
     taxYear: TaxYearModel,
     gain: BigDecimal,
     totalCosts: BigDecimal,
-    maxAEA: BigDecimal = 0)(implicit request: Request[_], messages: Messages)
+    maxAEA: BigDecimal = 0)(implicit messages: Messages)
 
 <div id="tax-owed-banner" class="govuk-panel govuk-panel--confirmation">
     <h1 class="govuk-panel__title">@Messages("calc.summary.cgtToPay", TaxYearModel.convertToSummaryFormat(taxYear.taxYearSupplied):_*)</h1>

--- a/app/views/playHelpers/inputRadio.scala.html
+++ b/app/views/playHelpers/inputRadio.scala.html
@@ -14,6 +14,9 @@
  * limitations under the License.
  *@
 
+@import uk.gov.hmrc.govukfrontend.views.html.components._
+@import uk.gov.hmrc.govukfrontend.views.html.components.implicits._
+
 @this(govukRadios : GovukRadios)
 
 @(

--- a/app/views/playHelpers/resident/summaryGainAndRateHelper.scala.html
+++ b/app/views/playHelpers/resident/summaryGainAndRateHelper.scala.html
@@ -18,7 +18,7 @@
 
 @this()
 
-@(rowId: String, question: String, firstBand: BigDecimal, firstRate: Int, secondBand: Option[BigDecimal], secondRate: Option[Int])(implicit messages: Messages)
+@(rowId: String, question: String, firstBand: BigDecimal, firstRate: Int, secondBand: Option[BigDecimal], secondRate: Option[Int])
 
 <div id="@rowId" class="grid-layout grid-layout--stacked form-group font-medium">
     <div id="@{rowId}-question" class="grid-layout__column grid-layout__column--1-2">

--- a/app/views/playHelpers/resident/summaryNumericHelpTextHelper.scala.html
+++ b/app/views/playHelpers/resident/summaryNumericHelpTextHelper.scala.html
@@ -22,10 +22,6 @@
 
 @(rowId: String, question: String, amount: BigDecimal, link: Option[String] = None, additionalContent: Option[Html] = None)(implicit messages: Messages)
 
-@additionalDetails(additionalText: String, additionalAmount: String) = {
-<span class="form-hint font-small">@additionalText &pound;@additionalAmount</span>
-}
-
 <div id="@rowId" class="grid-layout grid-layout--stacked form-group font-medium">
     <div id="@{rowId}-question" class="grid-layout__column grid-layout__column--1-2">
         @question

--- a/app/views/playHelpers/resident/summaryNumericRow.scala.html
+++ b/app/views/playHelpers/resident/summaryNumericRow.scala.html
@@ -18,7 +18,7 @@
 
 @this()
 
-@(rowId: String, question: String, amount: BigDecimal, isTotal: Boolean = false, hintText: Boolean = true)(implicit messages: Messages)
+@(rowId: String, question: String, amount: BigDecimal, isTotal: Boolean = false, hintText: Boolean = true)
 
 @(isTotal, hintText) match {
     case (true, _) => {

--- a/app/views/playHelpers/resident/summarySectionHeaderHelper.scala.html
+++ b/app/views/playHelpers/resident/summarySectionHeaderHelper.scala.html
@@ -16,7 +16,7 @@
 
 @this()
 
-@(sectionTitle: String)(implicit messages: Messages)
+@(sectionTitle: String)
 
 <h2 class="heading-large summary-underline">
     @sectionTitle

--- a/app/views/playHelpers/submitButton.scala.html
+++ b/app/views/playHelpers/submitButton.scala.html
@@ -14,6 +14,7 @@
  * limitations under the License.
  *@
 
+@import uk.gov.hmrc.govukfrontend.views.html.components._
 @this(govukButton : GovukButton)
 
 @(submitText: String = "calc.base.button.continue")(implicit messages: Messages)

--- a/build.sbt
+++ b/build.sbt
@@ -14,9 +14,6 @@
  * limitations under the License.
  */
 
-import com.typesafe.sbt.digest.Import.digest
-import com.typesafe.sbt.web.Import.{Assets, pipelineStages}
-
 lazy val appName = "cgt-calculator-resident-properties-frontend"
 
 lazy val microservice = Project(appName, file("."))
@@ -29,7 +26,6 @@ lazy val microservice = Project(appName, file("."))
     onLoadMessage := "",
     scalaVersion := "2.13.12",
     libraryDependencies ++= AppDependencies(),
-    Assets / pipelineStages := Seq(digest),
     scalacOptions += "-Wconf:cat=unused-imports&src=html/.*:s",
     scalacOptions += "-Wconf:cat=unused-imports&src=routes/.*:s",
     scalacOptions += "-feature",

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,40 +16,28 @@
 
 import com.typesafe.sbt.digest.Import.digest
 import com.typesafe.sbt.web.Import.{Assets, pipelineStages}
-import uk.gov.hmrc.DefaultBuildSettings.{defaultSettings, scalaSettings}
 
 lazy val appName = "cgt-calculator-resident-properties-frontend"
-lazy val plugins : Seq[Plugins] = Seq(play.sbt.PlayScala)
-lazy val playSettings : Seq[Setting[_]] = Seq.empty
 
 lazy val microservice = Project(appName, file("."))
-  .enablePlugins(Seq(play.sbt.PlayScala, SbtAutoBuildPlugin, SbtGitVersioning, SbtDistributablesPlugin) ++ plugins : _*)
+  .enablePlugins(play.sbt.PlayScala, SbtDistributablesPlugin)
   .disablePlugins(JUnitXmlReportPlugin) //Required to prevent https://github.com/scalatest/scalatest/issues/1427
   .settings(CodeCoverageSettings.settings : _*)
   .settings(majorVersion := 1)
-  .settings(playSettings : _*)
   .settings(PlayKeys.playDefaultPort := 9702)
-  .settings(scalaSettings: _*)
-  .settings(defaultSettings(): _*)
   .settings(
+    onLoadMessage := "",
     scalaVersion := "2.13.12",
     libraryDependencies ++= AppDependencies(),
-    retrieveManaged := true,
-    evictionWarningOptions in update := EvictionWarningOptions.default.withWarnScalaVersionEviction(false),
-    Global / lintUnusedKeysOnLoad := false,
-    pipelineStages in Assets := Seq(digest),
+    Assets / pipelineStages := Seq(digest),
     scalacOptions += "-Wconf:cat=unused-imports&src=html/.*:s",
     scalacOptions += "-Wconf:cat=unused-imports&src=routes/.*:s",
     scalacOptions += "-feature",
   )
-  .settings(resolvers += Resolver.jcenterRepo)
   .settings(TwirlKeys.templateImports ++= Seq(
     "uk.gov.hmrc.govukfrontend.views.html.components._",
     "uk.gov.hmrc.hmrcfrontend.views.html.components._",
     "uk.gov.hmrc.hmrcfrontend.views.html.helpers._",
     "uk.gov.hmrc.govukfrontend.views.html.components.implicits._"
   ))
-  .settings(
-    isPublicArtefact := true
-  )
-fork in run := true
+  .settings(isPublicArtefact := true)

--- a/build.sbt
+++ b/build.sbt
@@ -29,5 +29,13 @@ lazy val microservice = Project(appName, file("."))
     scalacOptions += "-Wconf:cat=unused-imports&src=html/.*:s",
     scalacOptions += "-Wconf:cat=unused-imports&src=routes/.*:s",
     scalacOptions += "-feature",
+    Test / testOptions -= Tests.Argument("-o", "-u", "target/test-reports", "-h", "target/test-reports/html-report"),
+    // Suppress successful events in Scalatest in standard output (-o)
+    // Options described here: https://www.scalatest.org/user_guide/using_scalatest_with_sbt
+    Test / testOptions += Tests.Argument(
+        TestFrameworks.ScalaTest,
+        "-oNCHPQR",
+        "-u", "target/test-reports",
+        "-h", "target/test-reports/html-report")
   )
   .settings(isPublicArtefact := true)

--- a/build.sbt
+++ b/build.sbt
@@ -30,10 +30,4 @@ lazy val microservice = Project(appName, file("."))
     scalacOptions += "-Wconf:cat=unused-imports&src=routes/.*:s",
     scalacOptions += "-feature",
   )
-  .settings(TwirlKeys.templateImports ++= Seq(
-    "uk.gov.hmrc.govukfrontend.views.html.components._",
-    "uk.gov.hmrc.hmrcfrontend.views.html.components._",
-    "uk.gov.hmrc.hmrcfrontend.views.html.helpers._",
-    "uk.gov.hmrc.govukfrontend.views.html.components.implicits._"
-  ))
   .settings(isPublicArtefact := true)

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -6,7 +6,7 @@
 GET         /assets/*file           controllers.Assets.versioned(path="/public", file: Asset)
 
 #Session Timeout route
-GET         /session-timeout        controllers.TimeoutController.timeout
+GET         /session-timeout        controllers.TimeoutController.timeout()
 
 #Language Controller
 GET         /language/:lang         @controllers.CgtLanguageController.switchToLanguage(lang: String)

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -20,16 +20,14 @@ import sbt.*
 object AppDependencies {
 
   val bootstrapVersion         = "8.4.0"
-  val playVersion               = "play-30"
-  val playPartialsVersion      = "9.1.0"
+  val playVersion              = "play-30"
   val hmrcMongoVersion         = "1.8.0"
 
   val compile: Seq[ModuleID] = Seq(
     ws,
     "uk.gov.hmrc.mongo" %% s"hmrc-mongo-$playVersion"           % hmrcMongoVersion,
     "uk.gov.hmrc"       %% s"bootstrap-frontend-$playVersion"   % bootstrapVersion,
-    "uk.gov.hmrc"       %% s"play-frontend-hmrc-$playVersion"   % "8.5.0",
-    "uk.gov.hmrc"       %% s"play-partials-$playVersion"        % playPartialsVersion
+    "uk.gov.hmrc"       %% s"play-frontend-hmrc-$playVersion"   % "8.5.0"
   )
 
   trait TestDependencies {
@@ -42,10 +40,7 @@ object AppDependencies {
       override lazy val test = Seq(
         "uk.gov.hmrc.mongo"       %%  s"hmrc-mongo-test-$playVersion" % hmrcMongoVersion                 % scope,
         "uk.gov.hmrc"             %% s"bootstrap-test-$playVersion"   % bootstrapVersion                 % scope,
-        "org.pegdown"             %  "pegdown"                        % "1.6.0"                          % scope,
         "org.jsoup"               %  "jsoup"                          % "1.17.2"                         % scope,
-        "com.typesafe.play"       %% "play-test"                      % "2.9.2"                          % scope,
-        "com.vladsch.flexmark"    %  "flexmark-all"                   % "0.64.8"                         % scope,
         "org.scalatestplus"       %% "scalatestplus-mockito"          % "1.0.0-M2"                       % scope,
         "org.scalatestplus"       %% "scalatestplus-scalacheck"       % "3.1.0.0-RC2"                    % scope,
         "org.scalatestplus.play"  %% "scalatestplus-play"             % "7.0.1"                          % scope,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,13 +2,9 @@ resolvers += "HMRC-open-artefacts-maven" at "https://open.artefacts.tax.service.
 resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.21.0")
-
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.5.0")
-
 addSbtPlugin("org.playframework" %% "sbt-plugin" % "3.0.2")
-
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.9")
-
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 
 excludeDependencies += ("org.scala-lang.modules" % "scala-xml_2.12")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -11,6 +11,4 @@ addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.9")
 
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.4")
-
 excludeDependencies += ("org.scala-lang.modules" % "scala-xml_2.12")

--- a/test/common/CommonPlaySpec.scala
+++ b/test/common/CommonPlaySpec.scala
@@ -43,7 +43,7 @@ trait CommonPlaySpec extends AnyWordSpecLike with Matchers with OptionValues {
   def status(of: Result): Int = of.header.status
 
   def bodyOf(result: Result)(implicit mat: Materializer): String = {
-    val bodyBytes: ByteString = await(result.body.consumeData)
+    val bodyBytes: ByteString = await(result.body.consumeData(mat))
     bodyBytes.decodeString(Charset.defaultCharset().name)
   }
 }

--- a/test/common/ValidationSpec.scala
+++ b/test/common/ValidationSpec.scala
@@ -16,335 +16,164 @@
 
 package common
 
-import common.Validation.{isValidDate, isPositive, decimalPlacesCheck, maxCheck, yesNoCheck, optionalMandatoryCheck, optionalYesNoCheck, bigDecimalCheck, mandatoryCheck}
+import org.scalatest.prop.TableDrivenPropertyChecks._
+import org.scalatest.prop.TableFor2
 import play.api.data.validation.{Invalid, Valid, ValidationError}
 
 import java.time.LocalDate
 
 class ValidationSpec extends CommonPlaySpec {
 
-  //############# Tests for isValidDate function ##########################################
-  "calling common.Validation.isValidDate(day, month, year) " should {
-
-    "with no day value supplied 'isValidDate(0,1,2016)' return false" in {
-      isValidDate(0, 1, 2016) shouldBe false
-    }
-
-    "with no month value supplied 'isValidDate(1,0,2016)' return false" in {
-      isValidDate(1, 0, 2016) shouldBe false
-    }
-
-    "with no year value supplied 'isValidDate(0,1,2016)' return false" in {
-      isValidDate(1, 1, 0) shouldBe false
-    }
-
-    "with invalid date 'isValidDate(32,1,2016)' return false" in {
-      isValidDate(32, 1, 2016) shouldBe false
-    }
-
-    "with invalid leap year date 'isValidDate(29,2,2017)' return false" in {
-      isValidDate(29, 2, 2017) shouldBe false
-    }
-
-    "with valid leap year date 'isValidDate(29,2,2016)' return true" in {
-      isValidDate(29, 2, 2016) shouldBe true
-    }
-
-    "with valid  date 'isValidDate(12,09,1990)' return true" in {
-      isValidDate(12, 9, 1990) shouldBe true
-    }
+  "calling common.Validation.isValidDate(day, month, year)" in {
+    val table = Table(
+      ("day", "month", "year", "expected"),
+      (0, 1, 2016, false),
+      (1, 0, 2016, false),
+      (32, 1, 2016, false),
+      (29, 2, 2017, false),
+      (29, 2, 2016, true),
+      (12, 9, 1990, true),
+    )
+    forAll(table) { (day, month, year, expected) => Validation.isValidDate(day, month, year) shouldBe expected }
   }
 
-
-  //############# Tests for isPositive function ##########################################
-  "calling common.Validation.isPositive(amount) " should {
-
-    "with a positive numeric supplied isPositive(1) return true" in {
-      isPositive(1) shouldBe true
-    }
-
-    "with Zero supplied return true" in {
-      isPositive(0) shouldBe true
-    }
-
-    "with Negative supplied return false" in {
-      isPositive(-1) shouldBe false
-    }
+  "calling common.Validation.isPositive(amount)" in {
+    val table = Table(
+      ("input", "expected"),
+      (1, true),
+      (0, true),
+      (-1, false),
+    )
+    forAll(table) { (input, expected) => Validation.isPositive(input) shouldBe expected }
   }
 
-
-  //############# Tests for decimalPlacesCheck ##########################################
-  "calling common.Validation.decimalPlacesCheck(amount) " should {
-
-    "with no decimals supplied decimalPlacesCheck(1) return true" in {
-      decimalPlacesCheck(1) shouldBe true
-    }
-
-    "with one decimal place supplied decimalPlacesCheck(1.1) return true" in {
-      decimalPlacesCheck(1.1) shouldBe true
-    }
-
-    "with two decimal places supplied decimalPlacesCheck(1.11) return true" in {
-      decimalPlacesCheck(1.11) shouldBe true
-    }
-
-    "with three decimal places supplied decimalPlacesCheck(1.111) return false" in {
-      decimalPlacesCheck(1.111) shouldBe false
-    }
+  "calling common.Validation.decimalPlacesCheck(amount)" in {
+    val table = Table(
+      ("input", "expected"),
+      (1.0, true),
+      (1.1, true),
+      (1.11, true),
+      (1.1111, false),
+    )
+    forAll(table) { (input, expected) => Validation.decimalPlacesCheck(input) shouldBe expected }
   }
 
-  //############# Tests for isLessThanMaxNumber ##########################################
-  "calling common.Validation.isGreaterThanMaxNumeric(amount) " should {
-
-    "with a value of 1000000000" in {
-      maxCheck(1000000000) shouldBe true
-    }
-
-    "with a value of 1000000000.01" in {
-      maxCheck(1000000000.01) shouldBe false
-    }
-
-    "with a value of 999999999.99" in {
-      maxCheck(999999999.99) shouldBe true
-    }
+  "calling common.Validation.isGreaterThanMaxNumeric(amount)" in {
+    val table = Table(
+      ("input", "expected"),
+      (1000000000.0, true),
+      (1000000000.01, false),
+      (999999999.99, true),
+    )
+    forAll(table) { (input, expected) => Validation.maxCheck(input) shouldBe expected }
   }
 
-  //############# Tests for yesNoCheck ##########################################
-  "calling common.Validation.yesNoCheck" should {
-
-    "return false with a non yes/no value" in {
-      yesNoCheck("a") shouldBe false
-    }
-
-    "return true with a yes value" in {
-      yesNoCheck("Yes") shouldBe true
-    }
-
-    "return true with a no value" in {
-      yesNoCheck("No") shouldBe true
-    }
+  "calling common.Validation.yesNoCheck" in {
+    val table = Table(
+      ("input", "expected"),
+      ("a", false),
+      ("Yes", true),
+      ("No", true),
+    )
+    forAll(table) { (input, expected) => Validation.yesNoCheck(input) shouldBe expected }
   }
 
-  "calling bigDecimalCheck" when {
-
-    "input contains non-numeric characters" should {
-      "fail" in {
-        bigDecimalCheck("abc") shouldBe false
-      }
-    }
-
-    "empty input" should {
-      "pass" in {
-        bigDecimalCheck("") shouldBe true
-      }
-    }
-
-    "empty space" should {
-      "pass" in {
-        bigDecimalCheck("   ") shouldBe true
-      }
-    }
-
-    "input only contains numeric characters" should {
-      "pass" in {
-        bigDecimalCheck("123") shouldBe true
-      }
-    }
+  "calling bigDecimalCheck" in {
+    val table = Table(
+      ("input", "expected"),
+      ("abc", false),
+      ("", true),
+      ("   ", true),
+      ("123", true),
+    )
+    forAll(table) { (input, expected) => Validation.bigDecimalCheck(input) shouldBe expected }
   }
 
-  "calling mandatoryCheck" when {
-
-    "input contains no data" should {
-      "fail" in {
-        mandatoryCheck("") shouldBe false
-      }
-    }
-
-    "input contains only empty space" should {
-      "fail" in {
-        mandatoryCheck("    ") shouldBe false
-      }
-    }
-
-    "input contains data" should {
-      "pass" in {
-        mandatoryCheck("123") shouldBe true
-      }
-    }
+  "calling mandatoryCheck" in {
+    val table = Table(
+      ("input", "expected"),
+      ("", false),
+      ("    ", false),
+      ("123", true),
+    )
+    forAll(table) { (input, expected) => Validation.mandatoryCheck(input) shouldBe expected }
   }
 
-  "calling decimalPlacesCheck" when {
-
-    "input has no decimal places" should {
-      "pass" in {
-        decimalPlacesCheck(BigDecimal(1)) shouldBe true
-      }
-    }
-
-    "input has 1 decimal place" should {
-      "pass" in {
-        decimalPlacesCheck(BigDecimal(1.1)) shouldBe true
-      }
-    }
-
-    "input has 2 decimal places" should {
-      "pass" in {
-        decimalPlacesCheck(BigDecimal(1.11)) shouldBe true
-      }
-    }
-
-    "input has 3 decimal places" should {
-      "fail" in {
-        decimalPlacesCheck(BigDecimal(1.111)) shouldBe false
-      }
-    }
+  "calling decimalPlacesCheck" in {
+    val table = Table(
+      ("input", "expected"),
+      (1.0, true),
+      (1.1, true),
+      (1.11, true),
+      (1.111, false),
+    )
+    forAll(table) { (input, expected) => Validation.decimalPlacesCheck(BigDecimal(input)) shouldBe expected }
   }
 
-  "calling maxCheck" when {
-
-    "input is less than max value" should {
-      "pass" in {
-        maxCheck(BigDecimal(900000000.99999)) shouldBe true
-      }
-    }
-
-    "input is equal to max value" should {
-      "pass" in {
-        maxCheck(BigDecimal(1000000000)) shouldBe true
-      }
-    }
-
-    "input is greater than max value" should {
-      "fail" in {
-        maxCheck(BigDecimal(1000000001)) shouldBe false
-      }
-    }
+  "calling maxCheck" in {
+    val table = Table(
+      ("input", "expected"),
+      (900000000.99999, true),
+      (1000000000.0, true),
+      (1000000001.0, false),
+    )
+    forAll(table) { (input, expected) => Validation.maxCheck(BigDecimal(input)) shouldBe expected }
   }
 
-  "calling isPositive" when {
-
-    "input is more than min value" should {
-      "pass" in {
-        isPositive(BigDecimal(0.01)) shouldBe true
-      }
-    }
-
-    "input is equal to min value" should {
-      "pass" in {
-        isPositive(BigDecimal(0)) shouldBe true
-      }
-    }
-
-    "input is less than min value" should {
-      "fail" in {
-        isPositive(BigDecimal(-0.01)) shouldBe false
-      }
-    }
+  "calling isPositive" in {
+    val table = Table(
+      ("input", "expected"),
+      (0.01, true),
+      (0.0, true),
+      (-0.01, false),
+    )
+    forAll(table) { (input, expected) => Validation.isPositive(BigDecimal(input)) shouldBe expected }
   }
   
-  "calling yesNoCheck" when {
-
-    "input is 'Yes'" should {
-      "pass" in {
-        yesNoCheck("Yes") shouldBe true
-      }
-    }
-
-    "input is 'No'" should {
-      "pass" in {
-        yesNoCheck("No") shouldBe true
-      }
-    }
-
-    "input is empty" should {
-      "pass" in {
-        yesNoCheck("") shouldBe true
-      }
-    }
-
-    "input is 'yEs'" should {
-      "fail" in {
-        yesNoCheck("yEs") shouldBe false
-      }
-    }
-
-    "input is 'nO'" should {
-      "fail" in {
-        yesNoCheck("nO") shouldBe false
-      }
-    }
-
-    "input is empty space" should {
-      "fail" in {
-        yesNoCheck("    ") shouldBe false
-      }
-    }
+  "calling yesNoCheck" in {
+    val table = Table(
+      ("input", "expected"),
+      ("Yes", true),
+      ("No", true),
+      ("", true),
+      ("yEs", false),
+      ("nO", false),
+      ("    ", false),
+    )
+    forAll(table) { (input, expected) => Validation.yesNoCheck(input) shouldBe expected }
   }
 
-  "Calling .optionalMandatoryCheck" should {
-
-    "return a false when an empty value is provided" in {
-      optionalMandatoryCheck(Some(" ")) shouldBe false
-    }
-
-    "return a false when no value is provided" in {
-      optionalMandatoryCheck(None) shouldBe false
-    }
-
-    "return a true when a value is provided" in {
-      optionalMandatoryCheck(Some("test")) shouldBe true
-    }
+  "Calling .optionalMandatoryCheck" in {
+    val table = Table(
+      ("input", "expected"),
+      (Some(" "), false),
+      (None, false),
+      (Some("test"), true),
+    )
+    forAll(table) { (input, expected) => Validation.optionalMandatoryCheck(input) shouldBe expected }
   }
 
-  "Calling .optionalYesNoCheck" should {
-
-    "return a true when no value is provided" in {
-      optionalYesNoCheck(None) shouldBe true
-    }
-
-    "return a true when an empty value is provided" in {
-      optionalYesNoCheck(Some("")) shouldBe true
-    }
-
-    "return a true when a Yes is provided" in {
-      optionalYesNoCheck(Some("Yes")) shouldBe true
-    }
-
-    "return a true when a No is provided" in {
-      optionalYesNoCheck(Some("No")) shouldBe true
-    }
-
-    "return a false when any other value is provided" in {
-      optionalYesNoCheck(Some("test")) shouldBe false
-    }
+  "Calling .optionalYesNoCheck" in {
+    val table: TableFor2[Option[String], Boolean] = Table(
+      ("input", "expected"),
+      (None, true),
+      (Some(""), true),
+      (Some("Yes"), true),
+      (Some("No"), true),
+      (Some("test"), false),
+    )
+    forAll(table) { (input, expected) => Validation.optionalYesNoCheck(input) shouldBe expected }
   }
 
-  "Calling .dateNotBeforeMinimum" should {
-
-    "return a true" when {
-
-      "provided with form data after the supplied minimum date" in {
-        Validation.dateAfterMinimum(6, 4, 2015, LocalDate.parse("2015-04-05")) shouldBe Valid
-      }
-
-      "provided with an invalid date" in {
-        Validation.dateAfterMinimum(100, 4, 2015, LocalDate.parse("2015-04-05")) shouldBe Invalid(List(ValidationError(List("calc.common.date.error.beforeMinimum"),"5 4 2015")))
-      }
-    }
-
-    "return a false" when {
-
-      "provided with form data for the supplied minimum date" in {
-        Validation.dateAfterMinimum(5, 4, 2015, LocalDate.parse("2015-04-05")) shouldBe Invalid(List(ValidationError(List("calc.common.date.error.beforeMinimum"),"5 4 2015")))
-      }
-
-      "provided with form data before the supplied minimum date" in {
-        Validation.dateAfterMinimum(4, 4, 2015, LocalDate.parse("2015-04-05")) shouldBe Invalid(List(ValidationError(List("calc.common.date.error.beforeMinimum"),"5 4 2015")))
-      }
-
-      "provided with a different minimum date making the form date invalid" in {
-        Validation.dateAfterMinimum(6, 4, 2015, LocalDate.parse("2015-04-08")) shouldBe Invalid(List(ValidationError(List("calc.common.date.error.beforeMinimum"),"8 4 2015")))
-      }
-    }
+  "Calling .dateNotBeforeMinimum" in {
+    val table = Table(
+      ("day", "month", "year", "date", "expected"),
+      (6, 4, 2015, LocalDate.parse("2015-04-05"), Valid),
+      (100, 4, 2015, LocalDate.parse("2015-04-05"), Invalid(List(ValidationError(List("calc.common.date.error.beforeMinimum"),"5 4 2015")))),
+      (5, 4, 2015, LocalDate.parse("2015-04-05"), Invalid(List(ValidationError(List("calc.common.date.error.beforeMinimum"),"5 4 2015")))),
+      (4, 4, 2015, LocalDate.parse("2015-04-05"), Invalid(List(ValidationError(List("calc.common.date.error.beforeMinimum"),"5 4 2015")))),
+      (6, 4, 2015, LocalDate.parse("2015-04-08"), Invalid(List(ValidationError(List("calc.common.date.error.beforeMinimum"),"8 4 2015")))),
+    )
+    forAll(table) { (day, month, year, date, expected) => Validation.dateAfterMinimum(day, month, year, date) shouldBe expected }
   }
 }

--- a/test/common/ValidationSpec.scala
+++ b/test/common/ValidationSpec.scala
@@ -16,7 +16,7 @@
 
 package common
 
-import common.Validation._
+import common.Validation.{isValidDate, isPositive, decimalPlacesCheck, maxCheck, yesNoCheck, optionalMandatoryCheck, optionalYesNoCheck, bigDecimalCheck, mandatoryCheck}
 import play.api.data.validation.{Invalid, Valid, ValidationError}
 
 import java.time.LocalDate

--- a/test/common/ValidationSpec.scala
+++ b/test/common/ValidationSpec.scala
@@ -39,128 +39,128 @@ class ValidationSpec extends CommonPlaySpec {
 
   "calling common.Validation.isPositive(amount)" in {
     val table = Table(
-      ("input", "expected"),
-      (1, true),
-      (0, true),
-      (-1, false),
+      "input" -> "expected",
+      1 -> true,
+      0 -> true,
+      -1 -> false,
     )
     forAll(table) { (input, expected) => Validation.isPositive(input) shouldBe expected }
   }
 
   "calling common.Validation.decimalPlacesCheck(amount)" in {
     val table = Table(
-      ("input", "expected"),
-      (1.0, true),
-      (1.1, true),
-      (1.11, true),
-      (1.1111, false),
+      "input" -> "expected",
+      1.0 -> true,
+      1.1 -> true,
+      1.11 -> true,
+      1.1111 -> false,
     )
     forAll(table) { (input, expected) => Validation.decimalPlacesCheck(input) shouldBe expected }
   }
 
   "calling common.Validation.isGreaterThanMaxNumeric(amount)" in {
     val table = Table(
-      ("input", "expected"),
-      (1000000000.0, true),
-      (1000000000.01, false),
-      (999999999.99, true),
+      "input" -> "expected",
+      1000000000.0 -> true,
+      1000000000.01 -> false,
+      999999999.99 -> true,
     )
     forAll(table) { (input, expected) => Validation.maxCheck(input) shouldBe expected }
   }
 
   "calling common.Validation.yesNoCheck" in {
     val table = Table(
-      ("input", "expected"),
-      ("a", false),
-      ("Yes", true),
-      ("No", true),
+      "input" -> "expected",
+      "a" -> false,
+      "Yes" -> true,
+      "No" -> true,
     )
     forAll(table) { (input, expected) => Validation.yesNoCheck(input) shouldBe expected }
   }
 
   "calling bigDecimalCheck" in {
     val table = Table(
-      ("input", "expected"),
-      ("abc", false),
-      ("", true),
-      ("   ", true),
-      ("123", true),
+      "input" -> "expected",
+      "abc" -> false,
+      "" -> true,
+      "   " -> true,
+      "123" -> true,
     )
     forAll(table) { (input, expected) => Validation.bigDecimalCheck(input) shouldBe expected }
   }
 
   "calling mandatoryCheck" in {
     val table = Table(
-      ("input", "expected"),
-      ("", false),
-      ("    ", false),
-      ("123", true),
+      "input" -> "expected",
+      "" -> false,
+      "    " -> false,
+      "123" -> true,
     )
     forAll(table) { (input, expected) => Validation.mandatoryCheck(input) shouldBe expected }
   }
 
   "calling decimalPlacesCheck" in {
     val table = Table(
-      ("input", "expected"),
-      (1.0, true),
-      (1.1, true),
-      (1.11, true),
-      (1.111, false),
+      "input" -> "expected",
+      1.0 -> true,
+      1.1 -> true,
+      1.11 -> true,
+      1.111 -> false,
     )
     forAll(table) { (input, expected) => Validation.decimalPlacesCheck(BigDecimal(input)) shouldBe expected }
   }
 
   "calling maxCheck" in {
     val table = Table(
-      ("input", "expected"),
-      (900000000.99999, true),
-      (1000000000.0, true),
-      (1000000001.0, false),
+      "input" -> "expected",
+      900000000.99999 -> true,
+      1000000000.0 -> true,
+      1000000001.0 -> false,
     )
     forAll(table) { (input, expected) => Validation.maxCheck(BigDecimal(input)) shouldBe expected }
   }
 
   "calling isPositive" in {
     val table = Table(
-      ("input", "expected"),
-      (0.01, true),
-      (0.0, true),
-      (-0.01, false),
+      "input" -> "expected",
+      0.01 -> true,
+      0.0 -> true,
+      -0.01 -> false,
     )
     forAll(table) { (input, expected) => Validation.isPositive(BigDecimal(input)) shouldBe expected }
   }
   
   "calling yesNoCheck" in {
     val table = Table(
-      ("input", "expected"),
-      ("Yes", true),
-      ("No", true),
-      ("", true),
-      ("yEs", false),
-      ("nO", false),
-      ("    ", false),
+      "input" -> "expected",
+      "Yes" -> true,
+      "No" -> true,
+      "" -> true,
+      "yEs" -> false,
+      "nO" -> false,
+      "    " -> false,
     )
     forAll(table) { (input, expected) => Validation.yesNoCheck(input) shouldBe expected }
   }
 
   "Calling .optionalMandatoryCheck" in {
     val table = Table(
-      ("input", "expected"),
-      (Some(" "), false),
-      (None, false),
-      (Some("test"), true),
+      "input" -> "expected",
+      Some(" ") -> false,
+      None -> false,
+      Some("test") -> true,
     )
     forAll(table) { (input, expected) => Validation.optionalMandatoryCheck(input) shouldBe expected }
   }
 
   "Calling .optionalYesNoCheck" in {
     val table: TableFor2[Option[String], Boolean] = Table(
-      ("input", "expected"),
-      (None, true),
-      (Some(""), true),
-      (Some("Yes"), true),
-      (Some("No"), true),
-      (Some("test"), false),
+      "input" -> "expected",
+      None -> true,
+      Some("") -> true,
+      Some("Yes") -> true,
+      Some("No") -> true,
+      Some("test") -> false,
     )
     forAll(table) { (input, expected) => Validation.optionalYesNoCheck(input) shouldBe expected }
   }

--- a/test/controllers/RecoverableFutureSpec.scala
+++ b/test/controllers/RecoverableFutureSpec.scala
@@ -33,13 +33,14 @@ class RecoverableFutureSpec extends AnyWordSpec with ScalaFutures with Matchers 
 
 
       val future: Future[Result] = Future.failed(new NoSuchElementException("test message")).recoverToStart()
-      val url = controllers.routes.TimeoutController.timeout.url
+      val url = controllers.routes.TimeoutController.timeout().url
 
       whenReady(future.failed) {
         case ApplicationException(result, message) =>
           result.header.headers should contain("Location" -> url)
           result.header.status shouldBe SEE_OTHER
           message should equal("cgt-calculator-resident-properties-frontendtest message")
+        case e => throw e
       }
     }
 

--- a/test/resources/logback-test.xml
+++ b/test/resources/logback-test.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+        <file>logs/cgt-calculator-resident-properties-frontend.log</file>
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>%date{ISO8601} level=[%level] logger=[%logger] thread=[%thread] message=[%message]
+                %replace(exception=[%xException]){'^exception=\[\]$',''}%n
+            </pattern>
+        </encoder>
+    </appender>
+    <root level="OFF" />
+</configuration>

--- a/test/services/SessionCacheServiceSpec.scala
+++ b/test/services/SessionCacheServiceSpec.scala
@@ -108,7 +108,7 @@ class SessionCacheServiceSpec extends CommonPlaySpec with MockitoSugar with Comm
       lazy val result: Future[YourAnswersSummaryModel] = sessionCacheService.getPropertyGainAnswers
 
       intercept[ApplicationException](await(result)) shouldBe ApplicationException(
-        Redirect(controllers.routes.TimeoutController.timeout), "None.get"
+        Redirect(controllers.routes.TimeoutController.timeout()), "None.get"
       )
     }
   }

--- a/test/views/resident/PersonalAllowanceViewSpec.scala
+++ b/test/views/resident/PersonalAllowanceViewSpec.scala
@@ -196,8 +196,6 @@ class PersonalAllowanceViewSpec extends CommonPlaySpec with WithCommonFakeApplic
         Some("back-link"), JourneyKeys.properties, "navTitle", Dates.getCurrentTaxYear)(fakeRequest, testingMessages)
       lazy val doc = Jsoup.parse(view.body)
       lazy val h1Tag = doc.select("H1")
-      lazy val header = doc.getElementsByClass("govuk-heading-xl")
-      val nextTaxYear = await(DateAsset.getYearAfterCurrentTaxYear)
 
       s"have the page heading '${messages.currentYearTitle}'" in {
         h1Tag.text shouldBe messages.currentYearTitle

--- a/test/views/resident/helpers/DeductionsSummaryPartialViewSpec.scala
+++ b/test/views/resident/helpers/DeductionsSummaryPartialViewSpec.scala
@@ -76,7 +76,7 @@ class DeductionsSummaryPartialViewSpec extends CommonPlaySpec with WithCommonFak
       val taxYearModel = TaxYearModel("2015/16", isValidYear = true, "2015/16")
 
       lazy val view = deductionsSummaryPartialView(gainAnswers, deductionAnswers, results,
-        taxYearModel, 100)(fakeRequestWithSession, testingMessages)
+        taxYearModel, 100)(testingMessages)
       lazy val doc = Jsoup.parse(view.body)
 
       "has a banner" which {
@@ -343,8 +343,7 @@ class DeductionsSummaryPartialViewSpec extends CommonPlaySpec with WithCommonFak
       )
       val taxYearModel = TaxYearModel("2015/16", isValidYear = true, "2015/16")
 
-      lazy val view = deductionsSummaryPartialView(gainAnswers, deductionAnswers, results,
-        taxYearModel, 100)(fakeRequestWithSession, testingMessages)
+      lazy val view = deductionsSummaryPartialView(gainAnswers, deductionAnswers, results, taxYearModel, 100)(testingMessages)
       lazy val doc = Jsoup.parse(view.body)
 
       "has a row for worth when sold for less" which {
@@ -405,8 +404,7 @@ class DeductionsSummaryPartialViewSpec extends CommonPlaySpec with WithCommonFak
       )
       val taxYearModel = TaxYearModel("2015/16", isValidYear = true, "2015/16")
 
-      lazy val view = deductionsSummaryPartialView(gainAnswers, deductionAnswers, results,
-        taxYearModel, 100)(fakeRequestWithSession, testingMessages)
+      lazy val view = deductionsSummaryPartialView(gainAnswers, deductionAnswers, results, taxYearModel, 100)(testingMessages)
       lazy val doc = Jsoup.parse(view.body)
 
       "has a row for reliefs used" which {
@@ -466,8 +464,7 @@ class DeductionsSummaryPartialViewSpec extends CommonPlaySpec with WithCommonFak
       )
       val taxYearModel = TaxYearModel("2015/16", isValidYear = true, "2015/16")
 
-      lazy val view = deductionsSummaryPartialView(gainAnswers, deductionAnswers, results,
-        taxYearModel, 100)(fakeRequestWithSession, testingMessages)
+      lazy val view = deductionsSummaryPartialView(gainAnswers, deductionAnswers, results, taxYearModel, 100)(testingMessages)
       lazy val doc = Jsoup.parse(view.body)
 
       "has a row for brought forward losses used" which {
@@ -532,8 +529,7 @@ class DeductionsSummaryPartialViewSpec extends CommonPlaySpec with WithCommonFak
       )
       val taxYearModel = TaxYearModel("2015/16", isValidYear = true, "2015/16")
 
-      lazy val view = deductionsSummaryPartialView(gainAnswers, deductionAnswers, results,
-        taxYearModel, 100)(fakeRequestWithSession, testingMessages)
+      lazy val view = deductionsSummaryPartialView(gainAnswers, deductionAnswers, results, taxYearModel, 100)(testingMessages)
       lazy val doc = Jsoup.parse(view.body)
 
       "has a row for brought forward losses used" which {
@@ -604,8 +600,7 @@ class DeductionsSummaryPartialViewSpec extends CommonPlaySpec with WithCommonFak
       )
       val taxYearModel = TaxYearModel("2015/16", isValidYear = true, "2015/16")
 
-      lazy val view = deductionsSummaryPartialView(gainAnswers, deductionAnswers, results,
-        taxYearModel, 100)(fakeRequestWithSession, testingMessages)
+      lazy val view = deductionsSummaryPartialView(gainAnswers, deductionAnswers, results, taxYearModel, 100)(testingMessages)
       lazy val doc = Jsoup.parse(view.body)
 
       "has a row for acquisition value" which {
@@ -665,8 +660,7 @@ class DeductionsSummaryPartialViewSpec extends CommonPlaySpec with WithCommonFak
       )
       val taxYearModel = TaxYearModel("2015/16", isValidYear = true, "2015/16")
 
-      lazy val view = deductionsSummaryPartialView(gainAnswers, deductionAnswers, results,
-        taxYearModel, 100)(fakeRequestWithSession, testingMessages)
+      lazy val view = deductionsSummaryPartialView(gainAnswers, deductionAnswers, results, taxYearModel, 100)(testingMessages)
       lazy val doc = Jsoup.parse(view.body)
 
       "has a row for value when the property was given away" which {
@@ -727,8 +721,7 @@ class DeductionsSummaryPartialViewSpec extends CommonPlaySpec with WithCommonFak
       )
       val taxYearModel = TaxYearModel("2018/19", isValidYear = false, "2016/17")
 
-      lazy val view = deductionsSummaryPartialView(gainAnswers, deductionAnswers, results,
-        taxYearModel, 100)(fakeRequestWithSession, testingMessages)
+      lazy val view = deductionsSummaryPartialView(gainAnswers, deductionAnswers, results, taxYearModel, 100)(testingMessages)
       lazy val doc = Jsoup.parse(view.body)
 
       s"display a notice summary with text ${summaryMessages.noticeSummary}" in {
@@ -782,7 +775,7 @@ class DeductionsSummaryPartialViewSpec extends CommonPlaySpec with WithCommonFak
       val taxYearModel = TaxYearModel("2015/16", isValidYear = true, "2015/16")
 
       lazy val view = deductionsSummaryPartialView(gainAnswers, deductionAnswers, results,
-        taxYearModel, 100)(fakeRequestWithSession, testingMessages)
+        taxYearModel, 100)(testingMessages)
       lazy val doc = Jsoup.parse(view.body)
 
       "has a row for acquisition value" which {
@@ -842,7 +835,7 @@ class DeductionsSummaryPartialViewSpec extends CommonPlaySpec with WithCommonFak
       val taxYearModel = TaxYearModel("2015/16", isValidYear = true, "2015/16")
 
       lazy val view = deductionsSummaryPartialView(gainAnswers, deductionAnswers, results,
-        taxYearModel, 100)(fakeRequestWithSession, testingMessages)
+        taxYearModel, 100)(testingMessages)
       lazy val doc = Jsoup.parse(view.body)
 
       "has a row for acquisition value" which {
@@ -902,7 +895,7 @@ class DeductionsSummaryPartialViewSpec extends CommonPlaySpec with WithCommonFak
       val taxYearModel = TaxYearModel("2015/16", isValidYear = true, "2015/16")
 
       lazy val view = deductionsSummaryPartialView(gainAnswers, deductionAnswers, results,
-        taxYearModel, 100)(fakeRequestWithSession, testingMessages)
+        taxYearModel, 100)(testingMessages)
       lazy val doc = Jsoup.parse(view.body)
 
       "has a row for acquisition value" which {

--- a/test/views/resident/helpers/FinalSummaryPartialViewSpec.scala
+++ b/test/views/resident/helpers/FinalSummaryPartialViewSpec.scala
@@ -85,7 +85,7 @@ class FinalSummaryPartialViewSpec extends CommonPlaySpec with WithCommonFakeAppl
       val taxYearModel = TaxYearModel("2015/16", isValidYear = true, "2015/16")
 
       lazy val view = finalSummaryPartialView(gainAnswers, deductionAnswers, incomeAnswers, results,
-        taxYearModel, None, None, 100, 100)(fakeRequestWithSession, testingMessages)
+        taxYearModel, None, None, 100, 100)(testingMessages)
       lazy val doc = Jsoup.parse(view.body)
 
       "has a banner" which {
@@ -380,7 +380,7 @@ class FinalSummaryPartialViewSpec extends CommonPlaySpec with WithCommonFakeAppl
       val taxYearModel = TaxYearModel("2015/16", isValidYear = true, "2015/16")
 
       lazy val view = finalSummaryPartialView(gainAnswers, deductionAnswers, incomeAnswers, results,
-        taxYearModel, None, None, 100, 100)(fakeRequestWithSession, testingMessages)
+        taxYearModel, None, None, 100, 100)(testingMessages)
       lazy val doc = Jsoup.parse(view.body)
 
       "has a row for worth when sold for less" which {
@@ -446,7 +446,7 @@ class FinalSummaryPartialViewSpec extends CommonPlaySpec with WithCommonFakeAppl
       val taxYearModel = TaxYearModel("2015/16", isValidYear = true, "2015/16")
 
       lazy val view = finalSummaryPartialView(gainAnswers, deductionAnswers, incomeAnswers, results, taxYearModel,
-        None, None, 100, 100)(fakeRequestWithSession, testingMessages)
+        None, None, 100, 100)(testingMessages)
       lazy val doc = Jsoup.parse(view.body)
 
       "has a numeric output row and a tax rate" which {
@@ -526,7 +526,7 @@ class FinalSummaryPartialViewSpec extends CommonPlaySpec with WithCommonFakeAppl
       val taxYearModel = TaxYearModel("2015/16", isValidYear = true, "2015/16")
 
       lazy val view = finalSummaryPartialView(gainAnswers, deductionAnswers, incomeAnswers, results,
-        taxYearModel, None, None, 100, 100)(fakeRequestWithSession, testingMessages)
+        taxYearModel, None, None, 100, 100)(testingMessages)
       lazy val doc = Jsoup.parse(view.body)
 
 
@@ -592,7 +592,7 @@ class FinalSummaryPartialViewSpec extends CommonPlaySpec with WithCommonFakeAppl
       val taxYearModel = TaxYearModel("2015/16", isValidYear = true, "2015/16")
 
       lazy val view = finalSummaryPartialView(gainAnswers, deductionAnswers, incomeAnswers, results,
-        taxYearModel, None, None, 100, 100)(fakeRequestWithSession, testingMessages)
+        taxYearModel, None, None, 100, 100)(testingMessages)
       lazy val doc = Jsoup.parse(view.body)
 
       "has a row for brought forward losses used" which {
@@ -661,7 +661,7 @@ class FinalSummaryPartialViewSpec extends CommonPlaySpec with WithCommonFakeAppl
       val taxYearModel = TaxYearModel("2015/16", isValidYear = true, "2015/16")
 
       lazy val view = finalSummaryPartialView(gainAnswers, deductionAnswers, incomeAnswers, results,
-        taxYearModel, None, None, 100, 100)(fakeRequestWithSession, testingMessages)
+        taxYearModel, None, None, 100, 100)(testingMessages)
       lazy val doc = Jsoup.parse(view.body)
 
       "has a row for acquisition value" which {
@@ -725,7 +725,7 @@ class FinalSummaryPartialViewSpec extends CommonPlaySpec with WithCommonFakeAppl
       val taxYearModel = TaxYearModel("2015/16", isValidYear = true, "2015/16")
 
       lazy val view = finalSummaryPartialView(gainAnswers, deductionAnswers, incomeAnswers, results,
-        taxYearModel, None, None, 100, 100)(fakeRequestWithSession, testingMessages)
+        taxYearModel, None, None, 100, 100)(testingMessages)
       lazy val doc = Jsoup.parse(view.body)
 
       "has a row for acquisition value" which {
@@ -788,7 +788,7 @@ class FinalSummaryPartialViewSpec extends CommonPlaySpec with WithCommonFakeAppl
       val taxYearModel = TaxYearModel("2015/16", isValidYear = true, "2015/16")
 
       lazy val view = finalSummaryPartialView(gainAnswers, deductionAnswers, incomeAnswers, results,
-        taxYearModel, None, None, 100, 100)(fakeRequestWithSession, testingMessages)
+        taxYearModel, None, None, 100, 100)(testingMessages)
       lazy val doc = Jsoup.parse(view.body)
 
       "has a row for acquisition value" which {
@@ -851,7 +851,7 @@ class FinalSummaryPartialViewSpec extends CommonPlaySpec with WithCommonFakeAppl
       val taxYearModel = TaxYearModel("2015/16", isValidYear = true, "2015/16")
 
       lazy val view = finalSummaryPartialView(gainAnswers, deductionAnswers, incomeAnswers, results,
-        taxYearModel, None, None, 100, 100)(fakeRequestWithSession, testingMessages)
+        taxYearModel, None, None, 100, 100)(testingMessages)
       lazy val doc = Jsoup.parse(view.body)
 
       "has a row for acquisition value" which {
@@ -916,7 +916,7 @@ class FinalSummaryPartialViewSpec extends CommonPlaySpec with WithCommonFakeAppl
       val taxYearModel = TaxYearModel("2015/16", isValidYear = true, "2015/16")
 
       lazy val view = finalSummaryPartialView(gainAnswers, deductionAnswers, incomeAnswers, results,
-        taxYearModel, None, None, 100, 100)(fakeRequestWithSession, testingMessages)
+        taxYearModel, None, None, 100, 100)(testingMessages)
       lazy val doc = Jsoup.parse(view.body)
 
       "has a row for value when the property was given away" which {
@@ -982,7 +982,7 @@ class FinalSummaryPartialViewSpec extends CommonPlaySpec with WithCommonFakeAppl
       val taxYearModel = TaxYearModel("2018/19", isValidYear = false, "2016/17")
 
       lazy val view = finalSummaryPartialView(gainAnswers, deductionAnswers, incomeAnswers, results,
-        taxYearModel, None, None, 100, 100)(fakeRequestWithSession, testingMessages)
+        taxYearModel, None, None, 100, 100)(testingMessages)
       lazy val doc = Jsoup.parse(view.body)
 
       s"display a notice summary with text ${summaryMessages.noticeSummary}" in {
@@ -1041,7 +1041,7 @@ class FinalSummaryPartialViewSpec extends CommonPlaySpec with WithCommonFakeAppl
 
 
       lazy val view = finalSummaryPartialView(gainAnswers, deductionAnswers, incomeAnswers, results,
-        taxYearModel, None, None, 100, 100)(fakeRequestWithSession, testingMessages)
+        taxYearModel, None, None, 100, 100)(testingMessages)
       lazy val doc = Jsoup.parse(view.body)
 
       s"have no taxable rate section" in {

--- a/test/views/resident/helpers/GainSummaryPartialViewSpec.scala
+++ b/test/views/resident/helpers/GainSummaryPartialViewSpec.scala
@@ -51,7 +51,7 @@ class GainSummaryPartialViewSpec extends CommonPlaySpec with  WithCommonFakeAppl
 
     val taxYearModel = TaxYearModel("2015/16", isValidYear = true, "2015/16")
 
-    lazy val view = gainSummaryPartialView(gainAnswers, taxYearModel, -100, 150, 11000)(fakeRequestWithSession, testingMessages)
+    lazy val view = gainSummaryPartialView(gainAnswers, taxYearModel, -100, 150, 11000)(testingMessages)
     lazy val doc = Jsoup.parse(view.body)
 
     "has a banner" which {
@@ -300,7 +300,7 @@ class GainSummaryPartialViewSpec extends CommonPlaySpec with  WithCommonFakeAppl
 
     val taxYearModel = TaxYearModel("2015/16", isValidYear = true, "2015/16")
 
-    lazy val view = gainSummaryPartialView(gainAnswers, taxYearModel, -100, 150, 11000)(fakeRequestWithSession, testingMessages)
+    lazy val view = gainSummaryPartialView(gainAnswers, taxYearModel, -100, 150, 11000)(testingMessages)
     lazy val doc = Jsoup.parse(view.body)
 
     "has a row for acquisition value" which {
@@ -339,7 +339,7 @@ class GainSummaryPartialViewSpec extends CommonPlaySpec with  WithCommonFakeAppl
 
     val taxYearModel = TaxYearModel("2015/16", isValidYear = true, "2015/16")
 
-    lazy val view = gainSummaryPartialView(gainAnswers, taxYearModel, 0, 150, 11000)(fakeRequestWithSession, testingMessages)
+    lazy val view = gainSummaryPartialView(gainAnswers, taxYearModel, 0, 150, 11000)(testingMessages)
 
   }
 
@@ -366,7 +366,7 @@ class GainSummaryPartialViewSpec extends CommonPlaySpec with  WithCommonFakeAppl
     )
     val taxYearModel = TaxYearModel("2015/16", isValidYear = true, "2015/16")
 
-    lazy val view = gainSummaryPartialView(gainAnswers, taxYearModel, -100, 150, 11000)(fakeRequestWithSession, testingMessages)
+    lazy val view = gainSummaryPartialView(gainAnswers, taxYearModel, -100, 150, 11000)(testingMessages)
     lazy val doc = Jsoup.parse(view.body)
 
     "has a row for value when the property was given away" which {
@@ -405,7 +405,7 @@ class GainSummaryPartialViewSpec extends CommonPlaySpec with  WithCommonFakeAppl
     )
     val taxYearModel = TaxYearModel("2018/19", isValidYear = false, "2016/17")
 
-    lazy val view = gainSummaryPartialView(gainAnswers, taxYearModel, -100, 150, 11000)(fakeRequestWithSession, testingMessages)
+    lazy val view = gainSummaryPartialView(gainAnswers, taxYearModel, -100, 150, 11000)(testingMessages)
     lazy val doc = Jsoup.parse(view.body)
 
     s"display a notice summary with text ${summaryMessages.noticeSummary}" in {
@@ -437,7 +437,7 @@ class GainSummaryPartialViewSpec extends CommonPlaySpec with  WithCommonFakeAppl
 
     val taxYearModel = TaxYearModel("2015/16", isValidYear = true, "2015/16")
 
-    lazy val view = gainSummaryPartialView(gainAnswers, taxYearModel, -100, 150, 11000)(fakeRequestWithSession, testingMessages)
+    lazy val view = gainSummaryPartialView(gainAnswers, taxYearModel, -100, 150, 11000)(testingMessages)
     lazy val doc = Jsoup.parse(view.body)
 
     "has a row for acquisition value" which {
@@ -474,7 +474,7 @@ class GainSummaryPartialViewSpec extends CommonPlaySpec with  WithCommonFakeAppl
     )
     val taxYearModel = TaxYearModel("2015/16", isValidYear = true, "2015/16")
 
-    lazy val view = gainSummaryPartialView(gainAnswers, taxYearModel, -100, 150, 11000)(fakeRequestWithSession, testingMessages)
+    lazy val view = gainSummaryPartialView(gainAnswers, taxYearModel, -100, 150, 11000)(testingMessages)
     lazy val doc = Jsoup.parse(view.body)
 
     "has a row for acquisition value" which {
@@ -511,7 +511,7 @@ class GainSummaryPartialViewSpec extends CommonPlaySpec with  WithCommonFakeAppl
     )
     val taxYearModel = TaxYearModel("2015/16", isValidYear = true, "2015/16")
 
-    lazy val view = gainSummaryPartialView(gainAnswers, taxYearModel, -100, 150, 11000)(fakeRequestWithSession, testingMessages)
+    lazy val view = gainSummaryPartialView(gainAnswers, taxYearModel, -100, 150, 11000)(testingMessages)
     lazy val doc = Jsoup.parse(view.body)
 
     "has a row for acquisition value" which {

--- a/test/views/resident/helpers/SummaryDateRowHelperSpec.scala
+++ b/test/views/resident/helpers/SummaryDateRowHelperSpec.scala
@@ -20,13 +20,13 @@ import assets.MessageLookup.{Resident => commonMessages}
 import common.CommonPlaySpec
 import common.Dates._
 import org.jsoup.Jsoup
+import play.api.i18n.Messages
 import views.BaseViewSpec
 import views.html.playHelpers.resident.summaryDateRowHelper
 
 class SummaryDateRowHelperSpec extends CommonPlaySpec with BaseViewSpec {
 
-  implicit val messages = testingMessages
-  implicit val lang = messages.lang
+  implicit val messages: Messages = testingMessages
 
   "The Summary Date Row Helper" when {
     lazy val summaryDateRowHelperView = fakeApplication.injector.instanceOf[summaryDateRowHelper]

--- a/test/views/resident/helpers/SummaryGainAndRateHelperSpec.scala
+++ b/test/views/resident/helpers/SummaryGainAndRateHelperSpec.scala
@@ -18,21 +18,21 @@ package views.resident.helpers
 
 import common.{CommonPlaySpec, WithCommonFakeApplication}
 import org.jsoup.Jsoup
+import play.api.i18n.Messages
 import views.BaseViewSpec
 import views.html.playHelpers.resident.summaryGainAndRateHelper
 
 class SummaryGainAndRateHelperSpec extends CommonPlaySpec with WithCommonFakeApplication with BaseViewSpec {
 
-  implicit val messages = testingMessages
-  implicit val lang = messages.lang
+  implicit val messages: Messages = testingMessages
 
-  lazy val summaryGainAndRateHelperView = fakeApplication.injector.instanceOf[summaryGainAndRateHelper]
+  private lazy val summaryGainAndRateHelperView = fakeApplication.injector.instanceOf[summaryGainAndRateHelper]
 
-  lazy val rowSingle = summaryGainAndRateHelperView("testID","testQ", 1000, 18, None, None)
-  lazy val docSingle = Jsoup.parse(rowSingle.body)
+  private lazy val rowSingle = summaryGainAndRateHelperView("testID","testQ", 1000, 18, None, None)
+  private lazy val docSingle = Jsoup.parse(rowSingle.body)
 
-  lazy val rowDouble = summaryGainAndRateHelperView("testID","testQ", 1000, 18, Some(2000), Some(28))
-  lazy val docDouble = Jsoup.parse(rowDouble.body)
+  private lazy val rowDouble = summaryGainAndRateHelperView("testID","testQ", 1000, 18, Some(2000), Some(28))
+  private lazy val docDouble = Jsoup.parse(rowDouble.body)
 
   "The Summary Gain and Rate Row Helper" should {
 

--- a/test/views/resident/helpers/SummaryNumericRowHelperSpec.scala
+++ b/test/views/resident/helpers/SummaryNumericRowHelperSpec.scala
@@ -19,13 +19,13 @@ package views.resident.helpers
 import assets.MessageLookup.{Resident => commonMessages}
 import common.{CommonPlaySpec, WithCommonFakeApplication}
 import org.jsoup.Jsoup
+import play.api.i18n.Messages
 import views.BaseViewSpec
 import views.html.playHelpers.resident.summaryNumericRowHelper
 
 class SummaryNumericRowHelperSpec extends CommonPlaySpec with WithCommonFakeApplication with BaseViewSpec {
 
-  implicit val messages = testingMessages
-  implicit val lang = messages.lang
+  implicit val messages: Messages = testingMessages
 
   "The Summary Numeric Row Helper" when {
     lazy val summaryNumericRowHelperView = fakeApplication.injector.instanceOf[summaryNumericRowHelper]

--- a/test/views/resident/helpers/SummaryOptionRowHelperSpec.scala
+++ b/test/views/resident/helpers/SummaryOptionRowHelperSpec.scala
@@ -20,14 +20,14 @@ import assets.MessageLookup.{Resident => commonMessages}
 import common.{CommonPlaySpec, WithCommonFakeApplication}
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
+import play.api.i18n.Messages
 import play.twirl.api.HtmlFormat
 import views.BaseViewSpec
 import views.html.playHelpers.resident.summaryOptionRowHelper
 
 class SummaryOptionRowHelperSpec extends CommonPlaySpec with WithCommonFakeApplication  with BaseViewSpec {
 
-  implicit val messages = testingMessages
-  implicit val lang = messages.lang
+  implicit val messages: Messages = testingMessages
 
   "The Summary Numeric Row Helper" when {
     lazy val summaryOptionRowHelperView = fakeApplication.injector.instanceOf[summaryOptionRowHelper]

--- a/test/views/resident/helpers/SummarySectionHeaderHelperSpec.scala
+++ b/test/views/resident/helpers/SummarySectionHeaderHelperSpec.scala
@@ -18,16 +18,18 @@ package views.resident.helpers
 
 import common.{CommonPlaySpec, WithCommonFakeApplication}
 import org.jsoup.Jsoup
+import org.jsoup.select.Elements
+import play.api.i18n.Messages
+import play.twirl.api.Html
 import views.BaseViewSpec
 import views.html.playHelpers.resident.summarySectionHeaderHelper
 
 class SummarySectionHeaderHelperSpec extends CommonPlaySpec with WithCommonFakeApplication  with BaseViewSpec {
 
-  implicit val messages = testingMessages
-  implicit val lang = messages.lang
-  lazy val summarySectionHeaderHelperView = fakeApplication.injector.instanceOf[summarySectionHeaderHelper]
-  lazy val TestObject = summarySectionHeaderHelperView("Heading")
-  lazy val h2 = Jsoup.parse(TestObject.body).select("H2")
+  implicit val messages: Messages = testingMessages
+  lazy val summarySectionHeaderHelperView: summarySectionHeaderHelper = fakeApplication.injector.instanceOf[summarySectionHeaderHelper]
+  lazy val TestObject: Html = summarySectionHeaderHelperView("Heading")
+  lazy val h2: Elements = Jsoup.parse(TestObject.body).select("H2")
 
   "The Summary Section Header Helper" should {
 

--- a/test/views/resident/helpers/SummaryTextRowHelperSpec.scala
+++ b/test/views/resident/helpers/SummaryTextRowHelperSpec.scala
@@ -20,14 +20,14 @@ import assets.MessageLookup.{Resident => commonMessages}
 import common.CommonPlaySpec
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
+import play.api.i18n.Messages
 import play.twirl.api.HtmlFormat
 import views.BaseViewSpec
 import views.html.playHelpers.resident.summaryTextRowHelper
 
 class SummaryTextRowHelperSpec extends CommonPlaySpec with BaseViewSpec {
 
-  implicit val messages = testingMessages
-  implicit val lang = messages.lang
+  implicit val messages: Messages = testingMessages
 
   "The Summary Text Row Helper" when {
     lazy val summaryTextRowHelperView = fakeApplication.injector.instanceOf[summaryTextRowHelper]

--- a/test/views/resident/properties/checkYourAnswers/CheckYourAnswersViewSpec.scala
+++ b/test/views/resident/properties/checkYourAnswers/CheckYourAnswersViewSpec.scala
@@ -22,7 +22,6 @@ import assets.ModelsAsset._
 import common.{CommonPlaySpec, WithCommonFakeApplication}
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
-import play.api.i18n.Lang
 import play.api.mvc.Call
 import play.twirl.api.HtmlFormat
 import views.BaseViewSpec
@@ -30,13 +29,12 @@ import views.html.calculation.resident.properties.checkYourAnswers.checkYourAnsw
 
 class CheckYourAnswersViewSpec extends CommonPlaySpec with WithCommonFakeApplication with BaseViewSpec {
 
-  val dummyBackLink = "#"
-  val dummyPostCall: Call = Call("POST", "/dummy-url")
-  val fakeLang: Lang = Lang("en")
-  lazy val checkYourAnswersView = fakeApplication.injector.instanceOf[checkYourAnswers]
-  lazy val view: HtmlFormat.Appendable = checkYourAnswersView(dummyPostCall, dummyBackLink, gainAnswersMostPossibles,
-    Some(deductionAnswersMostPossibles), Some(taxYearModel), Some(incomeAnswers))(fakeRequestWithSession, testingMessages, fakeLang)
-  lazy val doc: Document = Jsoup.parse(view.body)
+  private val dummyBackLink = "#"
+  private val dummyPostCall: Call = Call("POST", "/dummy-url")
+  private lazy val checkYourAnswersView = fakeApplication.injector.instanceOf[checkYourAnswers]
+  private lazy val view: HtmlFormat.Appendable = checkYourAnswersView(dummyPostCall, dummyBackLink, gainAnswersMostPossibles,
+    Some(deductionAnswersMostPossibles), Some(taxYearModel), Some(incomeAnswers))(fakeRequestWithSession, testingMessages)
+  private lazy val doc: Document = Jsoup.parse(view.body)
 
   "have a charset of UTF-8" in {
     doc.charset().toString shouldBe "UTF-8"

--- a/test/views/resident/properties/gain/AcquisitionCostsViewSpec.scala
+++ b/test/views/resident/properties/gain/AcquisitionCostsViewSpec.scala
@@ -98,7 +98,6 @@ class AcquisitionCostsViewSpec extends CommonPlaySpec with WithCommonFakeApplica
         }
 
         "have a div form-hint" which {
-          lazy val formHint = form.select("div.form-hint")
           s"has a paragraph with the text ${messages.listTitle}" in {
             doc.getElementById("listTitle").text shouldBe messages.listTitle
           }

--- a/test/views/resident/properties/gain/ValueBeforeLegislationStartViewSpec.scala
+++ b/test/views/resident/properties/gain/ValueBeforeLegislationStartViewSpec.scala
@@ -37,7 +37,6 @@ class ValueBeforeLegislationStartViewSpec extends CommonPlaySpec with WithCommon
 
   "Worth when gave away View" should {
 
-    lazy val backLink = Some(controllers.routes.GainController.ownerBeforeLegislationStart.toString())
     lazy val view = valueBeforeLegislationStartView(valueBeforeLegislationStartForm)(fakeRequest, testingMessages)
     lazy val doc = Jsoup.parse(view.body)
 
@@ -147,7 +146,6 @@ class ValueBeforeLegislationStartViewSpec extends CommonPlaySpec with WithCommon
   "Worth When Gave Away View with form without errors" should {
 
     lazy val form = valueBeforeLegislationStartForm.bind(Map("amount" -> "100"))
-    lazy val backLink = Some(controllers.routes.GainController.ownerBeforeLegislationStart.toString())
     lazy val view = valueBeforeLegislationStartView(form)(fakeRequest, testingMessages)
     lazy val doc = Jsoup.parse(view.body)
 
@@ -167,7 +165,6 @@ class ValueBeforeLegislationStartViewSpec extends CommonPlaySpec with WithCommon
   "Worth When Gave Away View with form with errors" should {
 
     lazy val form = valueBeforeLegislationStartForm.bind(Map("amount" -> ""))
-    lazy val backLink = Some(controllers.routes.GainController.ownerBeforeLegislationStart.toString())
     lazy val view = valueBeforeLegislationStartView(form)(fakeRequest, testingMessages)
     lazy val doc = Jsoup.parse(view.body)
 

--- a/test/views/resident/properties/gain/WorthWhenGaveAwayViewSpec.scala
+++ b/test/views/resident/properties/gain/WorthWhenGaveAwayViewSpec.scala
@@ -67,12 +67,6 @@ class WorthWhenGaveAwayViewSpec extends CommonPlaySpec with WithCommonFakeApplic
       }
     }
 
-    "have a help paragraph" should {
-      lazy val helpText = doc.select("#help")
-
-    }
-
-
     "have a form that" should {
 
       lazy val form = doc.select("form")

--- a/test/views/resident/properties/gain/WorthWhenSoldForLessViewSpec.scala
+++ b/test/views/resident/properties/gain/WorthWhenSoldForLessViewSpec.scala
@@ -80,8 +80,6 @@ class WorthWhenSoldForLessViewSpec extends CommonPlaySpec with WithCommonFakeApp
 
       "have an input for the amount" which {
 
-        lazy val input = doc.getElementById("#amount")
-
         "has a label" which {
 
           lazy val label = doc.select("label")

--- a/test/views/resident/properties/whatNext/SaUserViewSpec.scala
+++ b/test/views/resident/properties/whatNext/SaUserViewSpec.scala
@@ -26,10 +26,8 @@ import views.html.calculation.resident.properties.whatNext.saUser
 
 class SaUserViewSpec extends CommonPlaySpec with WithCommonFakeApplication with BaseViewSpec {
 
-  lazy val saUserView = fakeApplication.injector.instanceOf[saUser]
+  private lazy val saUserView = fakeApplication.injector.instanceOf[saUser]
   "SaUserView" when {
-    implicit lazy val fakeApp = fakeApplication
-
     "no errors are present" should {
       lazy val view = saUserView(SaUserForm.saUserForm)(fakeRequest, testingMessages)
       lazy val doc = Jsoup.parse(view.body)


### PR DESCRIPTION
Preliminary work for DLS-9341 - addresses most of the warnings raised during compilation, prunes dependencies and refactors tests with data-driven scala tests making them compile twice as fast.

Also, inline imports so that IntelliJ understands what these symbols are so that navigation works better.