### PR TITLE
mmudi/DLS-10770/v2 upgrade uri interpolation fix

### DIFF
--- a/app/constructors/resident/properties/CalculateRequestConstructor.scala
+++ b/app/constructors/resident/properties/CalculateRequestConstructor.scala
@@ -37,13 +37,15 @@ object CalculateRequestConstructor {
     case x => x.acquisitionValue.get
   }
 
-  def totalGainRequestString (answers: YourAnswersSummaryModel): String = {
-      s"?disposalValue=${determineDisposalValueToUse(answers).toDouble}" +
-      s"&disposalCosts=${answers.disposalCosts.toDouble}" +
-      s"&acquisitionValue=${determineAcquisitionValueToUse(answers).toDouble}" +
-      s"&acquisitionCosts=${answers.acquisitionCosts.toDouble}" +
-      s"&improvements=${answers.improvements.toDouble}" +
-      s"&disposalDate=${answers.disposalDate.format(requestFormatter)}"
+  def totalGainRequest(answers: YourAnswersSummaryModel): Map[String, String] = {
+    Map(
+      "disposalValue" -> determineDisposalValueToUse(answers).toDouble.toString,
+      "disposalCosts" -> answers.disposalCosts.toDouble.toString,
+      "acquisitionValue" -> determineAcquisitionValueToUse(answers).toDouble.toString,
+      "acquisitionCosts" -> answers.acquisitionCosts.toDouble.toString,
+      "improvements" -> answers.improvements.toDouble.toString,
+      "disposalDate" -> answers.disposalDate.format(requestFormatter)
+    )
   }
 
   def prrValue(answers: ChargeableGainAnswers): Map[String, String] = {
@@ -66,24 +68,21 @@ object CalculateRequestConstructor {
 
   def broughtForwardLosses(answers: ChargeableGainAnswers): Map[String, String] = {
     answers.broughtForwardModel match {
-      case (Some(x)) if x.option =>
+      case Some(x) if x.option =>
         Map("broughtForwardLosses" -> answers.broughtForwardValueModel.get.amount.toDouble.toString)
       case _ =>
         Map.empty
     }
   }
 
-  def toQS(map: Map[String, String]): String =
-    map.foldRight("") { (pair: (String, String), queryString: String) =>
-      s"${queryString}&${pair._1}=${pair._2}"
-    }
-
-  def chargeableGainRequestString(answers: ChargeableGainAnswers, maxAEA: BigDecimal): String = {
-    s"${toQS(prrValue(answers) ++ lettingReliefs(answers) ++ broughtForwardLosses(answers)) + "&annualExemptAmount=" + maxAEA.toDouble}"
+  def chargeableGainRequest(answers: ChargeableGainAnswers, maxAEA: BigDecimal): Map[String, Any] = {
+    prrValue(answers) ++ lettingReliefs(answers) ++ broughtForwardLosses(answers) ++ Map("annualExemptAmount" -> maxAEA.toDouble.toString)
   }
 
-  def incomeAnswersRequestString (deductionsAnswers: ChargeableGainAnswers, answers: IncomeAnswersModel): String = {
-    s"&previousIncome=${answers.currentIncomeModel.get.amount.toDouble}" +
-    s"&personalAllowance=${answers.personalAllowanceModel.get.amount.toDouble}"
+  def incomeAnswersRequest(deductionsAnswers: ChargeableGainAnswers, answers: IncomeAnswersModel): Map[String, Any] = {
+    Map(
+      "previousIncome" -> answers.currentIncomeModel.get.amount.toDouble,
+      "personalAllowance" -> answers.personalAllowanceModel.get.amount.toDouble
+    )
   }
 }

--- a/test/connectors/CalculatorConnectorSpec.scala
+++ b/test/connectors/CalculatorConnectorSpec.scala
@@ -72,7 +72,7 @@ class CalculatorConnectorSpec extends CommonPlaySpec with MockitoSugar with Wire
       when(
         GET,
         "/capital-gains-calculator/minimum-date"
-      )thenReturn (Status.OK,expectedResult)
+      ).thenReturn(Status.OK,expectedResult)
       await(connector.getMinimumDate()) shouldBe expectedResult
     }
 
@@ -90,7 +90,7 @@ class CalculatorConnectorSpec extends CommonPlaySpec with MockitoSugar with Wire
       when(
         GET,
         "/capital-gains-calculator/tax-rates-and-bands/max-full-aea",
-      )thenReturn(Status.OK,expectedResult)
+      ).thenReturn(Status.OK,expectedResult)
 
       val result = await(connector.getFullAEA(2017))
       result shouldBe expectedResult
@@ -101,7 +101,7 @@ class CalculatorConnectorSpec extends CommonPlaySpec with MockitoSugar with Wire
       when(
         GET,
         "/capital-gains-calculator/tax-rates-and-bands/max-full-aea"
-      )thenReturn (Status.OK, None)
+      ).thenReturn(Status.OK, None)
 
       val result = connector.getFullAEA(0)
       await(result) shouldBe None
@@ -115,7 +115,7 @@ class CalculatorConnectorSpec extends CommonPlaySpec with MockitoSugar with Wire
       when(
         GET,
         "/capital-gains-calculator/tax-rates-and-bands/max-partial-aea"
-      )thenReturn (Status.OK,expectedResult)
+      ).thenReturn(Status.OK,expectedResult)
 
       val result = connector.getPartialAEA(2017)
       await(result) shouldBe expectedResult
@@ -125,7 +125,7 @@ class CalculatorConnectorSpec extends CommonPlaySpec with MockitoSugar with Wire
       when(
         GET,
         "/capital-gains-calculator/tax-rates-and-bands/max-partial-aea"
-      )thenReturn (Status.OK,None)
+      ).thenReturn(Status.OK,None)
 
       val result = connector.getPartialAEA(1)
       await(result) shouldBe None
@@ -139,7 +139,7 @@ class CalculatorConnectorSpec extends CommonPlaySpec with MockitoSugar with Wire
       when(
         GET,
         req
-      )thenReturn (Status.OK,expectedResult)
+      ).thenReturn(Status.OK,expectedResult)
 
       val result = connector.getPA(2017,isEligibleBlindPersonsAllowance = true)
       await(result) shouldBe expectedResult
@@ -151,7 +151,7 @@ class CalculatorConnectorSpec extends CommonPlaySpec with MockitoSugar with Wire
       when(
         GET,
         req
-      )thenReturn (Status.OK,expectedResult)
+      ).thenReturn(Status.OK,expectedResult)
 
       val result = connector.getPA(2017,isEligibleBlindPersonsAllowance = false)
       await(result) shouldBe expectedResult
@@ -161,7 +161,7 @@ class CalculatorConnectorSpec extends CommonPlaySpec with MockitoSugar with Wire
       when(
         GET,
         "/capital-gains-calculator/tax-rates-and-bands/max-pa?taxYear=2"
-      )thenReturn (Status.OK,None)
+      ).thenReturn(Status.OK,None)
 
       val result = connector.getPA(2, isEligibleBlindPersonsAllowance = true)
       await(result) shouldBe None
@@ -175,7 +175,7 @@ class CalculatorConnectorSpec extends CommonPlaySpec with MockitoSugar with Wire
       when(
         GET,
         "/capital-gains-calculator/tax-year"
-      )thenReturn (Status.OK,Some(model))
+      ).thenReturn(Status.OK,Some(model))
 
 
       val result = connector.getTaxYear("2017")
@@ -187,7 +187,7 @@ class CalculatorConnectorSpec extends CommonPlaySpec with MockitoSugar with Wire
       when(
         GET,
         "/capital-gains-calculator/tax-year"
-      )thenReturn (Status.OK,None)
+      ).thenReturn(Status.OK,None)
 
 
       val result = connector.getTaxYear("3")
@@ -241,7 +241,7 @@ class CalculatorConnectorSpec extends CommonPlaySpec with MockitoSugar with Wire
       when(
         GET,
         "/capital-gains-calculator/calculate-total-gain"
-      )thenReturn (Status.OK,expectedResult)
+      ).thenReturn(Status.OK,expectedResult)
 
       val result = connector.calculateRttPropertyGrossGain(testYourAnswersSummaryModel)
       await(result) shouldBe expectedResult
@@ -255,7 +255,7 @@ class CalculatorConnectorSpec extends CommonPlaySpec with MockitoSugar with Wire
       when(
         GET,
         "/capital-gains-calculator/calculate-chargeable-gain"
-      )thenReturn (Status.OK,expectedResult)
+      ).thenReturn(Status.OK,expectedResult)
 
 
       val result = connector.calculateRttPropertyChargeableGain(testYourAnswersSummaryModel, testChargeableGainAnswersModel, BigDecimal(123.45))
@@ -272,7 +272,7 @@ class CalculatorConnectorSpec extends CommonPlaySpec with MockitoSugar with Wire
       when(
         GET,
         "/capital-gains-calculator/calculate-resident-capital-gains-tax",
-      )thenReturn (Status.OK,expectedResult)
+      ).thenReturn(Status.OK,expectedResult)
 
       val result = connector.calculateRttPropertyTotalGainAndTax(testYourAnswersSummaryModel,
                                                                                  testChargeableGainAnswersModel,
@@ -291,7 +291,7 @@ class CalculatorConnectorSpec extends CommonPlaySpec with MockitoSugar with Wire
       when(
         GET,
         "/capital-gains-calculator/calculate-total-costs"
-      )thenReturn (Status.OK,expectedResult)
+      ).thenReturn(Status.OK,expectedResult)
 
       val result = connector.getPropertyTotalCosts(testYourAnswersSummaryModel)
 

--- a/test/constructors/resident/properties/CalculateRequestConstructorSpec.scala
+++ b/test/constructors/resident/properties/CalculateRequestConstructorSpec.scala
@@ -315,13 +315,15 @@ class CalculateRequestConstructorSpec extends CommonPlaySpec {
           boughtForLessThanWorth = Some(true)
         )
 
-        val result = CalculateRequestConstructor.totalGainRequestString(answers)
-        result shouldBe s"?disposalValue=4000.0" +
-          s"&disposalCosts=0.0" +
-          s"&acquisitionValue=2000.0" +
-          s"&acquisitionCosts=100.0" +
-          s"&improvements=10.0" +
-          s"&disposalDate=2016-02-10"
+        val result = CalculateRequestConstructor.totalGainRequest(answers)
+        result shouldBe Map(
+          "disposalValue" -> "4000.0",
+          "disposalCosts" -> "0.0",
+          "acquisitionValue" -> "2000.0",
+          "acquisitionCosts" -> "100.0",
+          "improvements" -> "10.0",
+          "disposalDate" -> "2016-02-10"
+        )
       }
     }
   }
@@ -341,8 +343,8 @@ class CalculateRequestConstructorSpec extends CommonPlaySpec {
           None
         )
 
-        val result = CalculateRequestConstructor.chargeableGainRequestString(answers, BigDecimal(11100))
-        result shouldBe "&annualExemptAmount=11100.0"
+        val result = CalculateRequestConstructor.chargeableGainRequest(answers, BigDecimal(11100))
+        result shouldBe Map("annualExemptAmount" -> "11100.0")
 
         val prrValueResult = CalculateRequestConstructor.prrValue(answers)
         prrValueResult shouldBe Map()
@@ -367,8 +369,8 @@ class CalculateRequestConstructorSpec extends CommonPlaySpec {
           None,
           None
         )
-        val result = CalculateRequestConstructor.chargeableGainRequestString(answers, BigDecimal(11100))
-        result shouldBe "&annualExemptAmount=11100.0"
+        val result = CalculateRequestConstructor.chargeableGainRequest(answers, BigDecimal(11100))
+        result shouldBe Map("annualExemptAmount" -> "11100.0")
 
         val prrValueResult = CalculateRequestConstructor.prrValue(answers)
         prrValueResult shouldBe Map()
@@ -393,8 +395,14 @@ class CalculateRequestConstructorSpec extends CommonPlaySpec {
           Some(LettingsReliefModel(true)),
           Some(LettingsReliefValueModel(4000))
         )
-        val result = CalculateRequestConstructor.chargeableGainRequestString(answers, BigDecimal(11100))
-        result should (include("&prrValue=5000.0") and include("&lettingReliefs=4000.0") and include("&broughtForwardLosses=2000.0") and include("&annualExemptAmount=11100.0"))
+
+        val result = CalculateRequestConstructor.chargeableGainRequest(answers, BigDecimal(11100))
+        result shouldBe Map(
+          "prrValue" -> "5000.0",
+          "lettingReliefs" -> "4000.0",
+          "broughtForwardLosses" -> "2000.0",
+          "annualExemptAmount" -> "11100.0"
+        )
 
         val prrValueResult = CalculateRequestConstructor.prrValue(answers)
         prrValueResult shouldBe Map("prrValue" -> "5000.0")

--- a/test/util/WireMockMethods.scala
+++ b/test/util/WireMockMethods.scala
@@ -20,7 +20,6 @@ import com.github.tomakehurst.wiremock.client.MappingBuilder
 import com.github.tomakehurst.wiremock.client.WireMock._
 import com.github.tomakehurst.wiremock.matching.UrlPattern
 import com.github.tomakehurst.wiremock.stubbing.StubMapping
-import play.api.libs.json.Json.writes
 import play.api.libs.json.Writes
 
 import scala.jdk.CollectionConverters.MapHasAsJava


### PR DESCRIPTION
https://jira.tools.tax.service.gov.uk/browse/DLS-10770

**Bug fix**

With the recent changes to migrate the service to HttpClientV2 there were issues identified as part of ATs which is to do with url query parameters interpolation. As the new implementation now uses `url` interpolation than `string`, the query parameters need to be handled differently using `Map`. 

This has been verified by running the service locally and the current build failure on res-prop ui tests.

```
[info] Passed: Total 23, Failed 0, Errors 0, Passed 23
[success] Total time: 179 s (02:59), completed 15 Oct 2024, 15:08:44
[error] No accessibility assessment results to copy.
[success] Total time: 0 s, completed 15 Oct 2024, 15:08:44
```

## Checklist

 - [X]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [X]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [X]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [X]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
