### PR TITLE
Revert "DLS-10585 [CGTCALC-resident-properties] Error on POST /calculate-your-capital-gains/resident/properties/improvements"

### DIFF
--- a/app/controllers/GainController.scala
+++ b/app/controllers/GainController.scala
@@ -591,7 +591,7 @@ class GainController @Inject()(
   //################# Improvements Actions ########################
   private def getOwnerBeforeAprilNineteenEightyTwo()(implicit request: Request[?]): Future[Boolean] = {
     sessionCacheService.fetchAndGetFormData[OwnerBeforeLegislationStartModel](keystoreKeys.ownerBeforeLegislationStart)
-      .map(_.exists(_.ownedBeforeLegislationStart))
+      .map(_.get.ownedBeforeLegislationStart)
   }
 
   private def getImprovementsForm(ownerBeforeAprilNineteenEightyTwo: Boolean)(implicit request: Request[?]): Future[Form[ImprovementsModel]] = {

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -17,14 +17,14 @@
 import sbt.*
 
 object AppDependencies {
-  val bootstrapVersion         = "9.13.0"
+  val bootstrapVersion         = "9.12.0"
   val playVersion              = "play-30"
   val hmrcMongoVersion         = "2.6.0"
 
   val compile: Seq[ModuleID] = Seq(
     "uk.gov.hmrc.mongo" %% s"hmrc-mongo-$playVersion"           % hmrcMongoVersion,
     "uk.gov.hmrc"       %% s"bootstrap-frontend-$playVersion"   % bootstrapVersion,
-    "uk.gov.hmrc"       %% s"play-frontend-hmrc-$playVersion"   % "12.5.0"
+    "uk.gov.hmrc"       %% s"play-frontend-hmrc-$playVersion"   % "12.1.0"
   )
 
   def test(scope: String = "test"): Seq[ModuleID] = Seq(


### PR DESCRIPTION
Session time out error handling is already in place. So reverting this change.